### PR TITLE
feat(fs): add mkdir, rmdir recursively, touch, rm file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ file(GLOB_RECURSE SRC "${CMAKE_SOURCE_DIR}/src/*.c")
 include_directories(${CMAKE_SOURCE_DIR}/include)
 add_executable(cborg ${SRC})
 
+# TESTS
+include(CTest)
+add_executable(test_fs "${CMAKE_SOURCE_DIR}/tests/test_fs.c" "${CMAKE_SOURCE_DIR}/src/cb_fs.c")
+add_test(NAME test_fs COMMAND test_fs)
+
 # INSTALL CBORG
 install(TARGETS cborg DESTINATION ${CMAKE_INSTALL_BINDIR})
 

--- a/include/cb_fs.h
+++ b/include/cb_fs.h
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2021-present Adil Benhlal <abenhlal@cborgdb.com>
+ *
+ */
+
+#ifndef _CB_FS_H
+#define _CB_FS_H
+
+#include <stdlib.h>
+
+int cb_fs_mkdir(const char *path);
+
+int cb_fs_rmdir(const char *dir_path);
+
+int cb_fs_touch(const char *path);
+
+int cb_fs_remove(const char *path);
+
+int cb_fs_dir_exists(const char *path);
+
+int cb_fs_file_exists(const char *path);
+
+#endif // _CB_FS_H

--- a/src/cb_fs.c
+++ b/src/cb_fs.c
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2021-present Adil Benhlal <abenhlal@cborgdb.com>
+ *
+ */
+
+#ifdef __linux__
+// To avoid error compilation on DT_DIR and DT_REG 
+// Warning d_type in entry is not supported by all filesystem types
+#define _GNU_SOURCE 
+#include <linux/limits.h> // PATH_MAX
+#endif
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "cb_fs.h"
+
+int cb_fs_mkdir(const char *dir_path) { return mkdir(dir_path, 0777); }
+
+int cb_fs_rmdir(const char *dir_path) {
+  DIR *dirp;
+  struct dirent *entry;
+  char full_path[PATH_MAX + 1];
+
+  if ((dirp = opendir(dir_path)) == NULL)
+    return -1;
+
+  while ((entry = readdir(dirp)) != NULL) {
+    if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+      continue;
+
+    snprintf(full_path, sizeof(full_path), "%s/%s", dir_path, entry->d_name);
+
+    if (entry->d_type == DT_DIR && cb_fs_rmdir(full_path) == -1)
+      return -1;
+    else if (entry->d_type == DT_REG && unlink(full_path) == -1)
+      return -1;
+  }
+  closedir(dirp);
+
+  return rmdir(dir_path);
+}
+
+int cb_fs_touch(const char *path) {
+  int fd = open(path, O_WRONLY | O_CREAT , 0644);
+  if (fd < 0)
+    return -1;
+  close(fd);
+  return 0;
+}
+
+int cb_fs_remove(const char *path) {
+  return unlink(path);
+}
+
+int cb_fs_dir_exists(const char *path) {
+  struct stat stats;
+  return stat(path, &stats) == 0 && S_ISDIR(stats.st_mode);
+}
+
+int cb_fs_file_exists(const char *path) {
+  struct stat stats;
+  return stat(path, &stats) == 0 && S_ISREG(stats.st_mode);
+}

--- a/tests/test_fs.c
+++ b/tests/test_fs.c
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2021-present Adil Benhlal <abenhlal@cborgdb.com>
+ *
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "cb_fs.h"
+
+#define FAKE_DIRECTORY "./fake_directory"
+#define FAKE_FILE "./fake_directory/fake_file"
+#define FAKE_FILE_REMOVE "./fake_directory/fake_file_remove"
+#define FAKE_SUB_DIRECTORY "./fake_directory/fake_sub_directory"
+#define FAKE_SUB_DIRECTORY_REMOVE "./fake_directory/fake_sub_directory_remove"
+#define FAKE_SUB_FILE "./fake_directory/fake_sub_directory/fake_sub_file"
+
+void init() {
+  assert(cb_fs_mkdir(FAKE_DIRECTORY) == 0);
+}
+
+// rmdir: recursively
+void destroy() {
+  assert(cb_fs_rmdir(FAKE_DIRECTORY) == 0);
+}
+
+void test_cb_fs_mkdir() {
+  assert(cb_fs_mkdir(FAKE_SUB_DIRECTORY) == 0);
+  assert(cb_fs_mkdir(FAKE_SUB_DIRECTORY_REMOVE) == 0);
+}
+
+void test_cb_fs_touch() {
+  assert(cb_fs_touch(FAKE_FILE) == 0);
+  assert(cb_fs_touch(FAKE_SUB_FILE) == 0);
+  assert(cb_fs_touch(FAKE_FILE_REMOVE) == 0);
+}
+
+void test_cb_fs_dir_exists() {
+  assert(cb_fs_dir_exists(FAKE_DIRECTORY));
+  assert(cb_fs_dir_exists(FAKE_SUB_DIRECTORY));
+}
+
+void test_cb_fs_file_exists() {
+  assert(cb_fs_file_exists(FAKE_FILE));
+  assert(cb_fs_file_exists(FAKE_SUB_FILE));
+  assert(cb_fs_file_exists(FAKE_FILE_REMOVE));
+}
+
+void test_cb_fs_remove() {
+  assert(cb_fs_remove(FAKE_FILE_REMOVE) == 0);
+}
+
+// rmdir: empty directory
+void test_cb_fs_rmdir() {
+  assert(cb_fs_rmdir(FAKE_SUB_DIRECTORY_REMOVE) == 0);
+}
+
+// TODO: criterion or cmocka
+int main() {
+  init();
+
+  // TESTS
+  test_cb_fs_mkdir();
+  test_cb_fs_touch();
+  test_cb_fs_dir_exists();
+  test_cb_fs_file_exists();
+  test_cb_fs_remove();
+  test_cb_fs_rmdir();
+
+  destroy();
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
<!---
  Provide a general summary of your changes in the Title above 
  Examples:
    - "feat(bloom): ..."
    - "fix(cbor): ..."
-->

## Description
This PR add the following functions:
- cb_fs_mkdir: Create directory
- cb_fs_rmdir: Remove a directory recursively
- cb_fs_touch: Create an empty file
- cb_fs_remove: Remove a file
- cb_fs_dir_exists: Test if a directory exists
- cb_fs_file_exists: Test if a file exists

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For this MVP:
- a database is represented as a directory.
- a collection/ table is represented as a file.

So, we need 
- create and remove database/directory
- create and remove (collection or table)/file

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Each function is tested in the test_fs.c file with <assert.h> library.

### macOS Monterey v12.3.1

1) 🌱 Environment

```console
abenhlal@cborgdb:~/cborg/build$ uname -v
Darwin Kernel Version 21.4.0: Fri Mar 18 00:45:05 PDT 2022; root:xnu-8020.101.4~15/RELEASE_X86_64
```

```console
abenhlal@cborgdb:~/cborg/build$ cmake --version
cmake version 3.22.3

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

```console
abenhlal@cborgdb:~/cborg/build$ gcc --version
Apple clang version 13.1.6 (clang-1316.0.21.2.3)
Target: x86_64-apple-darwin21.4.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```



2) ⚙️ Build and tests

```console
abenhlal@cborgdb:~/cborg/build$ cmake ..
-- The C compiler identification is AppleClang 13.1.6.13160021
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/cborgdb/code/cborgdb/cborg/build
abenhlal@cborgdb:~/cborg/build$ make
[ 16%] Building C object CMakeFiles/cborg.dir/src/cb_fs.c.o
[ 33%] Building C object CMakeFiles/cborg.dir/src/cborg.c.o
/Users/cborgdb/code/cborgdb/cborg/src/cborg.c:14:14: warning: unused parameter 'argc' [-Wunused-parameter]
int main(int argc, char const *argv[]) {
             ^
/Users/cborgdb/code/cborgdb/cborg/src/cborg.c:14:32: warning: unused parameter 'argv' [-Wunused-parameter]
int main(int argc, char const *argv[]) {
                               ^
2 warnings generated.
[ 50%] Linking C executable cborg
[ 50%] Built target cborg
[ 66%] Building C object CMakeFiles/test_fs.dir/tests/test_fs.c.o
[ 83%] Building C object CMakeFiles/test_fs.dir/src/cb_fs.c.o
[100%] Linking C executable test_fs
[100%] Built target test_fs
abenhlal@cborgdb:~/cborg/build$ make test
Running tests...
Test project /Users/cborgdb/code/cborgdb/cborg/build
    Start 1: test_fs
1/1 Test #1: test_fs ..........................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.01 sec
```

### Debian GNU/Linux 11 (bullseye)

1) 🌱 Environment

```console
abenhlal@cborgdb-01:~/cborg/build$ uname -a
Linux cborgdb-01 5.10.0-11-amd64 #1 SMP Debian 5.10.92-1 (2022-01-18) x86_64 GNU/Linux
```

```console
abenhlal@cborgdb-01:~/cborg/build$ cmake --version
cmake version 3.18.4

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

```console
abenhlal@cborgdb-01:~/cborg/build$ gcc --version
gcc (Debian 10.2.1-6) 10.2.1 20210110
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

2) ⚙️ Build and tests

```console
abenhlal@cborgdb-01:~/cborg/build$ cmake ..
-- The C compiler identification is GNU 10.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/abenhlal/cborg/build
abenhlal@cborgdb-01:~/cborg/build$ make
Scanning dependencies of target test_fs
[ 16%] Building C object CMakeFiles/test_fs.dir/tests/test_fs.c.o
[ 33%] Building C object CMakeFiles/test_fs.dir/src/cb_fs.c.o
[ 50%] Linking C executable test_fs
[ 50%] Built target test_fs
Scanning dependencies of target cborg
[ 66%] Building C object CMakeFiles/cborg.dir/src/cb_fs.c.o
[ 83%] Building C object CMakeFiles/cborg.dir/src/cborg.c.o
/home/abenhlal/cborg/src/cborg.c: In function ‘main’:
/home/abenhlal/cborg/src/cborg.c:14:14: warning: unused parameter ‘argc’ [-Wunused-parameter]
   14 | int main(int argc, char const *argv[]) {
      |          ~~~~^~~~
/home/abenhlal/cborg/src/cborg.c:14:32: warning: unused parameter ‘argv’ [-Wunused-parameter]
   14 | int main(int argc, char const *argv[]) {
      |                    ~~~~~~~~~~~~^~~~~~
[100%] Linking C executable cborg
[100%] Built target cborg
abenhlal@cborgdb-01:~/cborg/build$ make test
Running tests...
Test project /home/abenhlal/cborg/build
    Start 1: test_fs
1/1 Test #1: test_fs ..........................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.00 sec
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
