### PR TITLE
feat(endianness): add endianness functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,12 @@ project(cborg VERSION 0.1.0 LANGUAGES C)
 # BUILD
 set(CMAKE_C_FLAGS "-std=c99 -Wall -Wextra -pedantic")
 
+include(TestBigEndian)
+test_big_endian(IS_BIG_ENDIAN)
+if(IS_BIG_ENDIAN)
+    add_definitions(-DIS_BIG_ENDIAN)
+endif()
+
 # Include module
 include(GNUInstallDirs)
 
@@ -16,6 +22,8 @@ add_executable(cborg ${SRC})
 include(CTest)
 add_executable(test_fs "${CMAKE_SOURCE_DIR}/tests/test_fs.c" "${CMAKE_SOURCE_DIR}/src/cb_fs.c")
 add_test(NAME test_fs COMMAND test_fs)
+add_executable(test_endianness "${CMAKE_SOURCE_DIR}/tests/test_endianness.c" "${CMAKE_SOURCE_DIR}/src/cb_endianness.c")
+add_test(NAME test_endianness COMMAND test_endianness)
 
 # INSTALL CBORG
 install(TARGETS cborg DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/include/cb_endianness.h
+++ b/include/cb_endianness.h
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2021-present Adil Benhlal <abenhlal@cborgdb.com>
+ *
+ */
+
+#ifndef _CB_ENDIANNESS_H
+#define _CB_ENDIANNESS_H
+
+#include <stdint.h>
+
+int cb_is_little_endian();
+
+uint16_t cb_bswap16(uint16_t v);
+
+uint32_t cb_bswap32(uint32_t v);
+
+uint64_t cb_bswap64(uint64_t v);
+
+#endif // _CB_ENDIANNESS_H

--- a/src/cb_endianness.c
+++ b/src/cb_endianness.c
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2021-present Adil Benhlal <abenhlal@cborgdb.com>
+ *
+ */
+
+#include "cb_endianness.h"
+
+int cb_is_little_endian() {
+  int x = 1;
+  return (int)*(char *)&x;
+}
+
+uint16_t cb_bswap16(uint16_t v) {
+  return ((v << 8 & 0xff00) | (v >> 8 & 0x00ff));
+}
+
+uint32_t cb_bswap32(uint32_t v) {
+  return (((v << 24) & 0xff000000) | ((v << 8) & 0x00ff0000) |
+          ((v >> 8) & 0x0000ff00) | ((v >> 24) & 0x000000ff));
+}
+
+uint64_t cb_bswap64(uint64_t v) {
+  return (
+      ((v << 56) & 0xff00000000000000ul) | ((v << 40) & 0x00ff000000000000ul) |
+      ((v << 24) & 0x0000ff0000000000ul) | ((v << 8) & 0x000000ff00000000ul) |
+      ((v >> 8) & 0x00000000ff000000ul) | ((v >> 24) & 0x0000000000ff0000ul) |
+      ((v >> 40) & 0x000000000000ff00ul) | ((v >> 56) & 0x00000000000000fful));
+}

--- a/tests/test_endianness.c
+++ b/tests/test_endianness.c
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2021-present Adil Benhlal <abenhlal@cborgdb.com>
+ *
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+
+#include "cb_endianness.h"
+
+void test_cb_bswap16() {
+  assert(cb_bswap16(0xDBBD) == 0xBDDB);
+  assert(cb_bswap16(cb_bswap16(0xDBBD)) == 0xDBBD);
+  assert(cb_bswap16(0xABCD) == 0xCDAB);
+  assert(cb_bswap16(cb_bswap16(0xABCD)) == 0xABCD);
+  assert(cb_bswap16(0x0000) == 0x0000);
+  assert(cb_bswap16(cb_bswap16(0x0000)) == 0x0000);
+  assert(cb_bswap16(0xFFFF) == 0xFFFF);
+  assert(cb_bswap16(cb_bswap16(0xFFFF)) == 0xFFFF);
+}
+
+void test_cb_bswap32() {
+  assert(cb_bswap32(0xDBABCDBD) == 0xBDCDABDB);
+  assert(cb_bswap32(cb_bswap32(0xDBABCDBD)) == 0xDBABCDBD);
+  assert(cb_bswap32(0xABCDEF98) == 0x98EFCDAB);
+  assert(cb_bswap32(cb_bswap32(0xABCDEF98)) == 0xABCDEF98);
+  assert(cb_bswap32(0x00000000) == 0x00000000);
+  assert(cb_bswap32(cb_bswap32(0x00000000)) == 0x00000000);
+  assert(cb_bswap32(0xFFFFFFFF) == 0xFFFFFFFF);
+  assert(cb_bswap32(cb_bswap32(0xFFFFFFFF)) == 0xFFFFFFFF);
+}
+
+void test_cb_bswap64() {
+  assert(cb_bswap64(0xABCDEF0123456789) == 0x8967452301EFCDAB);
+  assert(cb_bswap64(cb_bswap64(0xABCDEF0123456789)) == 0xABCDEF0123456789);
+  assert(cb_bswap64(0x123456789ABCDEF8) == 0xF8DEBC9A78563412);
+  assert(cb_bswap64(cb_bswap64(0x123456789ABCDEF8)) == 0x123456789ABCDEF8);
+  assert(cb_bswap64(0x0000000000000000) == 0x0000000000000000);
+  assert(cb_bswap64(cb_bswap64(0x0000000000000000)) == 0x0000000000000000);
+  assert(cb_bswap64(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFFFFFFFFFF);
+  assert(cb_bswap64(cb_bswap64(0xFFFFFFFFFFFFFFFF)) == 0xFFFFFFFFFFFFFFFF);
+}
+
+void test_cb_is_little_endian() {
+#ifdef IS_BIG_ENDIAN
+  assert(cb_is_little_endian() == 0);
+  assert((!cb_is_little_endian()) == 1);
+#else
+  assert(cb_is_little_endian() == 1);
+  assert((!cb_is_little_endian()) == 0);
+#endif
+}
+
+// TODO: criterion or cmocka
+int main() {
+  ///////////
+  // TESTS //
+  ///////////
+  test_cb_bswap16();
+  test_cb_bswap32();
+  test_cb_bswap64();
+  test_cb_is_little_endian();
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
<!---
  Provide a general summary of your changes in the Title above 
  Examples:
    - "feat(bloom): ..."
    - "fix(cbor): ..."
-->

## Description
This PR add the following functions:
- cb_bswap16: Swap 2 bytes
- cb_bswap32: Swap 4 bytes
- cb_bswap64: Swap 8 bytes

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It is necessary to take into account the endianness of the machines for the encoding and the decoding of the CBOR format
Also, these functions will be needed for other future needs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Each function is tested in the test_endianness.c file with <assert.h> library.

### macOS Monterey v12.3.1

1) 🌱 Environment

```console
abenhlal@cborgdb:~/cborg/build$ uname -v
Darwin Kernel Version 21.4.0: Fri Mar 18 00:45:05 PDT 2022; root:xnu-8020.101.4~15/RELEASE_X86_64
```

```console
abenhlal@cborgdb:~/cborg/build$ cmake --version
cmake version 3.22.3

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

```console
abenhlal@cborgdb:~/cborg/build$ gcc --version
Apple clang version 13.1.6 (clang-1316.0.21.2.3)
Target: x86_64-apple-darwin21.4.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```



2) ⚙️ Build and tests

```console
abenhlal@cborgdb:~/cborg/build$ cmake ..
-- The C compiler identification is AppleClang 13.1.6.13160021
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/cborgdb/code/cborgdb/cborg/build
abenhlal@cborgdb:~/cborg/build$ make
[ 10%] Building C object CMakeFiles/cborg.dir/src/cb_endianness.c.o
[ 20%] Building C object CMakeFiles/cborg.dir/src/cb_fs.c.o
[ 30%] Building C object CMakeFiles/cborg.dir/src/cborg.c.o
/Users/cborgdb/code/cborgdb/cborg/src/cborg.c:14:14: warning: unused parameter 'argc' [-Wunused-parameter]
int main(int argc, char const *argv[]) {
             ^
/Users/cborgdb/code/cborgdb/cborg/src/cborg.c:14:32: warning: unused parameter 'argv' [-Wunused-parameter]
int main(int argc, char const *argv[]) {
                               ^
2 warnings generated.
[ 40%] Linking C executable cborg
[ 40%] Built target cborg
[ 50%] Building C object CMakeFiles/test_fs.dir/tests/test_fs.c.o
[ 60%] Building C object CMakeFiles/test_fs.dir/src/cb_fs.c.o
[ 70%] Linking C executable test_fs
[ 70%] Built target test_fs
[ 80%] Building C object CMakeFiles/test_endianness.dir/tests/test_endianness.c.o
[ 90%] Building C object CMakeFiles/test_endianness.dir/src/cb_endianness.c.o
[100%] Linking C executable test_endianness
[100%] Built target test_endianness
abenhlal@cborgdb:~/cborg/build$ make test
Running tests...
Test project /Users/cborgdb/code/cborgdb/cborg/build
    Start 1: test_fs
1/2 Test #1: test_fs ..........................   Passed    0.00 sec
    Start 2: test_endianness
2/2 Test #2: test_endianness ..................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =   0.01 sec
```

### Debian GNU/Linux 11 (bullseye)

1) 🌱 Environment

```console
abenhlal@cborgdb-01:~/cborg/build$ uname -a
Linux cborgdb-01 5.10.0-11-amd64 #1 SMP Debian 5.10.92-1 (2022-01-18) x86_64 GNU/Linux
```

```console
abenhlal@cborgdb-01:~/cborg/build$ cmake --version
cmake version 3.18.4

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

```console
abenhlal@cborgdb-01:~/cborg/build$ gcc --version
gcc (Debian 10.2.1-6) 10.2.1 20210110
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

2) ⚙️ Build and tests

```console
abenhlal@cborgdb-01:~/cborg/build$ cmake ..
-- The C compiler identification is GNU 10.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Check if the system is big endian
-- Searching 16 bit integer
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of unsigned short
-- Check size of unsigned short - done
-- Searching 16 bit integer - Using unsigned short
-- Check if the system is big endian - little endian
-- Configuring done
-- Generating done
-- Build files have been written to: /home/abenhlal/cborg/build
abenhlal@cborgdb-01:~/cborg/build$ make
Scanning dependencies of target test_fs
[ 10%] Building C object CMakeFiles/test_fs.dir/tests/test_fs.c.o
[ 20%] Building C object CMakeFiles/test_fs.dir/src/cb_fs.c.o
[ 30%] Linking C executable test_fs
[ 30%] Built target test_fs
Scanning dependencies of target cborg
[ 40%] Building C object CMakeFiles/cborg.dir/src/cb_endianness.c.o
[ 50%] Building C object CMakeFiles/cborg.dir/src/cb_fs.c.o
[ 60%] Building C object CMakeFiles/cborg.dir/src/cborg.c.o
/home/abenhlal/cborg/src/cborg.c: In function ‘main’:
/home/abenhlal/cborg/src/cborg.c:14:14: warning: unused parameter ‘argc’ [-Wunused-parameter]
   14 | int main(int argc, char const *argv[]) {
      |          ~~~~^~~~
/home/abenhlal/cborg/src/cborg.c:14:32: warning: unused parameter ‘argv’ [-Wunused-parameter]
   14 | int main(int argc, char const *argv[]) {
      |                    ~~~~~~~~~~~~^~~~~~
[ 70%] Linking C executable cborg
[ 70%] Built target cborg
Scanning dependencies of target test_endianness
[ 80%] Building C object CMakeFiles/test_endianness.dir/tests/test_endianness.c.o
[ 90%] Building C object CMakeFiles/test_endianness.dir/src/cb_endianness.c.o
[100%] Linking C executable test_endianness
[100%] Built target test_endianness
abenhlal@cborgdb-01:~/cborg/build$ make test
Running tests...
Test project /home/abenhlal/cborg/build
    Start 1: test_fs
1/2 Test #1: test_fs ..........................   Passed    0.00 sec
    Start 2: test_endianness
2/2 Test #2: test_endianness ..................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =   0.01 sec
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
