### PR TITLE
feat(cbor): add encoding functions for uint and negint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ add_executable(test_fs "${CMAKE_SOURCE_DIR}/tests/test_fs.c" "${CMAKE_SOURCE_DIR
 add_test(NAME test_fs COMMAND test_fs)
 add_executable(test_endianness "${CMAKE_SOURCE_DIR}/tests/test_endianness.c" "${CMAKE_SOURCE_DIR}/src/cb_endianness.c")
 add_test(NAME test_endianness COMMAND test_endianness)
+add_executable(test_cbor "${CMAKE_SOURCE_DIR}/tests/test_cbor.c" "${CMAKE_SOURCE_DIR}/src/cb_cbor.c" "${CMAKE_SOURCE_DIR}/src/cb_endianness.c")
+add_test(NAME test_cbor COMMAND test_cbor)
 
 # INSTALL CBORG
 install(TARGETS cborg DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/include/cb_cbor.h
+++ b/include/cb_cbor.h
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2021-present Adil Benhlal <abenhlal@cborgdb.com>
+ *
+ */
+
+#ifndef _CB_CBOR_H
+#define _CB_CBOR_H
+
+#include <unistd.h>
+#include <stdint.h>
+
+// INT
+ssize_t cb_cbor_encode_uint8(uint8_t v, uint8_t *ev, ssize_t size);
+
+ssize_t cb_cbor_encode_uint16(uint16_t v, uint8_t *ev, ssize_t size);
+
+ssize_t cb_cbor_encode_uint32(uint32_t v, uint8_t *ev, ssize_t size);
+
+ssize_t cb_cbor_encode_uint64(uint64_t v, uint8_t *ev, ssize_t size);
+
+ssize_t cb_cbor_encode_uint(uint64_t v, uint8_t *ev, ssize_t size);
+
+// NEG INT
+ssize_t cb_cbor_encode_negint8(uint8_t v, uint8_t *ev, ssize_t size);
+
+ssize_t cb_cbor_encode_negint16(uint16_t v, uint8_t *ev, ssize_t size);
+
+ssize_t cb_cbor_encode_negint32(uint32_t v, uint8_t *ev, ssize_t size);
+
+ssize_t cb_cbor_encode_negint64(uint64_t v, uint8_t *ev, ssize_t size);
+
+ssize_t cb_cbor_encode_negint(uint64_t v, uint8_t *ev, ssize_t size);
+
+#endif // _CB_CBOR_H

--- a/src/cb_cbor.c
+++ b/src/cb_cbor.c
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2021-present Adil Benhlal <abenhlal@cborgdb.com>
+ *
+ */
+
+#include "cb_cbor.h"
+#include "cb_endianness.h"
+
+static inline ssize_t _cb_cbor_encode_uint8(uint8_t v, uint8_t *ev,
+                                            ssize_t size, uint8_t offset);
+
+static inline ssize_t _cb_cbor_encode_uint16(uint16_t v, uint8_t *ev,
+                                             ssize_t size, uint8_t offset);
+
+static inline ssize_t _cb_cbor_encode_uint32(uint32_t v, uint8_t *ev,
+                                             ssize_t size, uint8_t offset);
+
+static inline ssize_t _cb_cbor_encode_uint64(uint64_t v, uint8_t *ev,
+                                             ssize_t size, uint8_t offset);
+
+static inline ssize_t _cb_cbor_encode_uint(uint64_t v, uint8_t *ev,
+                                           ssize_t size, uint8_t offset);
+
+// INT
+ssize_t cb_cbor_encode_uint8(uint8_t v, uint8_t *ev, ssize_t size) {
+  return _cb_cbor_encode_uint8(v, ev, size, 0);
+}
+
+ssize_t cb_cbor_encode_uint16(uint16_t v, uint8_t *ev, ssize_t size) {
+  return _cb_cbor_encode_uint16(v, ev, size, 0);
+}
+
+ssize_t cb_cbor_encode_uint32(uint32_t v, uint8_t *ev, ssize_t size) {
+  return _cb_cbor_encode_uint32(v, ev, size, 0);
+}
+
+ssize_t cb_cbor_encode_uint64(uint64_t v, uint8_t *ev, ssize_t size) {
+  return _cb_cbor_encode_uint64(v, ev, size, 0);
+}
+
+ssize_t cb_cbor_encode_uint(uint64_t v, uint8_t *ev, ssize_t size) {
+  return _cb_cbor_encode_uint(v, ev, size, 0);
+}
+
+// NEG INT
+ssize_t cb_cbor_encode_negint8(uint8_t v, uint8_t *ev, ssize_t size) {
+  return _cb_cbor_encode_uint8(v, ev, size, 0x20);
+}
+
+ssize_t cb_cbor_encode_negint16(uint16_t v, uint8_t *ev, ssize_t size) {
+  return _cb_cbor_encode_uint16(v, ev, size, 0x20);
+}
+
+ssize_t cb_cbor_encode_negint32(uint32_t v, uint8_t *ev, ssize_t size) {
+  return _cb_cbor_encode_uint32(v, ev, size, 0x20);
+}
+
+ssize_t cb_cbor_encode_negint64(uint64_t v, uint8_t *ev, ssize_t size) {
+  return _cb_cbor_encode_uint64(v, ev, size, 0x20);
+}
+
+ssize_t cb_cbor_encode_negint(uint64_t v, uint8_t *ev, ssize_t size) {
+  return _cb_cbor_encode_uint(v, ev, size, 0x20);
+}
+
+//////////////
+// INTERNAL //
+//////////////
+static inline ssize_t _cb_cbor_encode_uint8(uint8_t v, uint8_t *ev,
+                                            ssize_t size, uint8_t offset) {
+  if (v < 24) {
+    if (size >= 1) {
+      ev[0] = v + offset;
+      return 1;
+    }
+  } else {
+    if (size >= 2) {
+      ev[0] = 24 + offset;
+      ev[1] = v;
+      return 2;
+    }
+  }
+  return 0;
+}
+
+static inline ssize_t _cb_cbor_encode_uint16(uint16_t v, uint8_t *ev,
+                                             ssize_t size, uint8_t offset) {
+  if (size >= 3) {
+    ev[0] = 25 + offset;
+#ifdef IS_BIG_ENDIAN
+    *((uint16_t *)(ev + 1)) = v;
+#else
+    *((uint16_t *)(ev + 1)) = cb_bswap16(v);
+#endif
+    return 3;
+  }
+  return 0;
+}
+
+static inline ssize_t _cb_cbor_encode_uint32(uint32_t v, uint8_t *ev,
+                                             ssize_t size, uint8_t offset) {
+  if (size >= 5) {
+    ev[0] = 26 + offset;
+#ifdef IS_BIG_ENDIAN
+    *((uint32_t *)(ev + 1)) = v;
+#else
+    *((uint32_t *)(ev + 1)) = cb_bswap32(v);
+#endif
+    return 5;
+  }
+  return 0;
+}
+
+static inline ssize_t _cb_cbor_encode_uint64(uint64_t v, uint8_t *ev,
+                                             ssize_t size, uint8_t offset) {
+  if (size >= 9) {
+    ev[0] = 27 + offset;
+#ifdef IS_BIG_ENDIAN
+    *((uint64_t *)(ev + 1)) = v;
+#else
+    *((uint64_t *)(ev + 1)) = cb_bswap64(v);
+#endif
+    return 9;
+  }
+  return 0;
+}
+
+static inline ssize_t _cb_cbor_encode_uint(uint64_t v, uint8_t *ev,
+                                           ssize_t size, uint8_t offset) {
+  if (v <= UINT16_MAX)
+    if (v <= UINT8_MAX)
+      return _cb_cbor_encode_uint8(v, ev, size, offset);
+    else
+      return _cb_cbor_encode_uint16(v, ev, size, offset);
+  else if (v <= UINT32_MAX)
+    return _cb_cbor_encode_uint32(v, ev, size, offset);
+  else
+    return _cb_cbor_encode_uint64(v, ev, size, offset);
+}

--- a/tests/test_cbor.c
+++ b/tests/test_cbor.c
@@ -1,0 +1,534 @@
+/**
+ * Copyright (c) 2021-present Adil Benhlal <abenhlal@cborgdb.com>
+ *
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "cb_cbor.h"
+
+// INT
+void test_cb_cbor_encode_uint8() {
+  // 1 byte
+  uint8_t ev_one_byte[2] = {0xEF, 0xEF}; // encoded value
+  uint8_t min_one_byte[2] = {0x00, 0xEF}; // 0
+  uint8_t middle_one_byte[2] = {0x10, 0xEF}; // 16
+  uint8_t max_one_byte[2] = {0x17, 0xEF}; // 23
+  assert(cb_cbor_encode_uint8(0, ev_one_byte, 1) == 1);
+  assert(memcmp(min_one_byte, ev_one_byte, 2) == 0);
+  assert(cb_cbor_encode_uint8(16, ev_one_byte, 1) == 1);
+  assert(memcmp(middle_one_byte, ev_one_byte, 2) == 0);
+  assert(cb_cbor_encode_uint8(23, ev_one_byte, 1) == 1);
+  assert(memcmp(max_one_byte, ev_one_byte, 2) == 0);
+
+  // 2 bytes
+  uint8_t ev_two_byte[2] = {0xFF, 0xEF};
+  uint8_t min_two_byte[2] = {0x18, 0x18}; // 24
+  uint8_t middle_two_byte[2] = {0x18, 0xAB}; // 171
+  uint8_t max_two_byte[2] = {0x18, 0xFF};  // UINT8_MAX == 255
+
+  assert(cb_cbor_encode_uint8(24, ev_two_byte, 2) == 2);
+  assert(memcmp(min_two_byte, ev_two_byte, 2) == 0);
+  assert(cb_cbor_encode_uint8(171, ev_two_byte, 2) == 2);
+  assert(memcmp(middle_two_byte, ev_two_byte, 2) == 0);
+  assert(cb_cbor_encode_uint8(UINT8_MAX, ev_two_byte, 2) == 2);
+  assert(memcmp(max_two_byte, ev_two_byte, 2) == 0);
+
+  // Size tests
+  uint8_t ev_ts[2] = {0xFF, 0xEF};
+  uint8_t no_change[2] = {0xFF, 0xEF};
+  // 0
+  assert(cb_cbor_encode_uint8(0, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 2) == 0);
+  // 16
+  assert(cb_cbor_encode_uint8(16, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 2) == 0);
+  // 23
+  assert(cb_cbor_encode_uint8(23, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 2) == 0);
+  // 24
+  assert(cb_cbor_encode_uint8(24, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 2) == 0);
+  assert(cb_cbor_encode_uint8(24, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 2) == 0);
+  // 171
+  assert(cb_cbor_encode_uint8(171, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 2) == 0);
+  assert(cb_cbor_encode_uint8(171, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 2) == 0);
+  // UINT8_MAX
+  assert(cb_cbor_encode_uint8(UINT8_MAX, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 2) == 0);
+  assert(cb_cbor_encode_uint8(UINT8_MAX, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 2) == 0);
+}
+
+void test_cb_cbor_encode_uint16() {
+  // encoded value
+  uint8_t ev[3] = {0xFF, 0xEF, 0xEF};
+  // CBOR(0x190100) == UINT8_MAX + 1
+  uint8_t min[3] = {0x19, 0x01, 0x00};
+  // CBOR(0x19ABCD) == 43981
+  uint8_t middle[3] = {0x19, 0xAB, 0xCD};
+  // CBOR(0x19FFFF) == UINT16_MAX
+  uint8_t max[3] = {0x19, 0xFF, 0xFF};
+
+  assert(cb_cbor_encode_uint16(256, ev, 3) == 3);
+  assert(memcmp(min, ev, 3) == 0);
+  assert(cb_cbor_encode_uint16(43981, ev, 3) == 3);
+  assert(memcmp(middle, ev, 3) == 0);
+  assert(cb_cbor_encode_uint16(UINT16_MAX, ev, 3) == 3);
+  assert(memcmp(max, ev, 3) == 0);
+
+  // Size tests
+  uint8_t ev_ts[3] = {0xFF, 0xEF, 0xEF}; // encoded value
+  uint8_t no_change[3] = {0xFF, 0xEF, 0xEF};
+  // UINT8_MAX + 1 == 256
+  assert(cb_cbor_encode_uint16(256, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 3) == 0);
+  assert(cb_cbor_encode_uint16(256, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 3) == 0);
+  assert(cb_cbor_encode_uint16(256, ev_ts, 2) == 0);
+  assert(memcmp(no_change, ev_ts, 3) == 0);
+  // 43981
+  assert(cb_cbor_encode_uint16(43981, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 3) == 0);
+  assert(cb_cbor_encode_uint16(43981, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 3) == 0);
+  assert(cb_cbor_encode_uint16(43981, ev_ts, 2) == 0);
+  assert(memcmp(no_change, ev_ts, 3) == 0);
+  // UINT16_MAX
+  assert(cb_cbor_encode_uint16(UINT16_MAX, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 3) == 0);
+  assert(cb_cbor_encode_uint16(UINT16_MAX, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 3) == 0);
+  assert(cb_cbor_encode_uint16(UINT16_MAX, ev_ts, 2) == 0);
+  assert(memcmp(no_change, ev_ts, 3) == 0);
+}
+
+void test_cb_cbor_encode_uint32() {
+  // encoded value
+  uint8_t ev[5] = {0xFF, 0xEF, 0xEF, 0xEF, 0xEF};
+  // CBOR(0x1A00010000) == UINT16_MAX + 1
+  uint8_t min[5] = {0x1A, 0x00, 0x01, 0x00, 0x00};
+  // CBOR(0x1AABCD1234) == 2882343476
+  uint8_t middle[5] = {0x1A, 0xAB, 0xCD, 0x12, 0x34};
+  // CBOR(0x1AFFFFFFFF) == UINT32_MAX
+  uint8_t max[5] = {0x1A, 0xFF, 0xFF, 0xFF, 0xFF};
+
+  assert(cb_cbor_encode_uint32(65536U, ev, 5) == 5);
+  assert(memcmp(min, ev, 5) == 0);
+  assert(cb_cbor_encode_uint32(2882343476U, ev, 5) == 5);
+  assert(memcmp(middle, ev, 5) == 0);
+  assert(cb_cbor_encode_uint32(UINT32_MAX, ev, 5) == 5);
+  assert(memcmp(max, ev, 5) == 0);
+
+  // Size tests
+  uint8_t ev_ts[5] = {0xFF, 0xEF, 0xEF, 0xEF, 0xEF}; // encoded value
+  uint8_t no_change[5] = {0xFF, 0xEF, 0xEF, 0xEF, 0xEF};
+  // UINT16_MAX + 1 == 65536
+  assert(cb_cbor_encode_uint32(65536U, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_uint32(65536U, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_uint32(65536U, ev_ts, 2) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_uint32(65536U, ev_ts, 3) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_uint32(65536U, ev_ts, 4) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  // 2882343476
+  assert(cb_cbor_encode_uint32(2882343476U, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_uint32(2882343476U, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_uint32(2882343476U, ev_ts, 2) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_uint32(2882343476U, ev_ts, 3) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_uint32(2882343476U, ev_ts, 4) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  // UINT32_MAX
+  assert(cb_cbor_encode_uint32(UINT32_MAX, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_uint32(UINT32_MAX, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_uint32(UINT32_MAX, ev_ts, 2) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_uint32(UINT32_MAX, ev_ts, 3) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_uint32(UINT32_MAX, ev_ts, 4) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+
+}
+
+void test_cb_cbor_encode_uint64() {
+  // encoded value
+  uint8_t ev[9] = {0xFF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF};
+  // CBOR(0x1B0000000100000000) == UINT32_MAX + 1 == 4294967296
+  uint8_t min[9] = {0x1B, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00};
+  // CBOR(0x1BABCD123434567890) == 12379813812177893520
+  uint8_t middle[9] = {0x1B, 0xAB, 0xCD, 0xEF, 0x12, 0x34, 0x56, 0x78, 0x90};
+  // CBOR(0x1BFFFFFFFFFFFFFFFF) == UINT64_MAX
+  uint8_t max[9] = {0x1B, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+  
+  assert(cb_cbor_encode_uint64(4294967296ULL, ev, 9) == 9);
+  assert(memcmp(min, ev, 9) == 0);
+  assert(cb_cbor_encode_uint64(12379813812177893520ULL, ev, 9) == 9);
+  assert(memcmp(middle, ev, 9) == 0);
+  assert(cb_cbor_encode_uint64(UINT64_MAX, ev, 9) == 9);
+  assert(memcmp(max, ev, 9) == 0);
+
+  // Size tests
+  uint8_t ev_ts[9] = {0xFF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF};
+  uint8_t no_change[9] = {0xFF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF};
+  // UINT32_MAX + 1 == 4294967296
+  assert(cb_cbor_encode_uint64(4294967296ULL, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(4294967296ULL, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(4294967296ULL, ev_ts, 2) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(4294967296ULL, ev_ts, 3) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(4294967296ULL, ev_ts, 4) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(4294967296ULL, ev_ts, 5) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(4294967296ULL, ev_ts, 6) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(4294967296ULL, ev_ts, 7) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(4294967296ULL, ev_ts, 8) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  // 2882343476
+  assert(cb_cbor_encode_uint64(12379813812177893520ULL, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(12379813812177893520ULL, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(12379813812177893520ULL, ev_ts, 2) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(12379813812177893520ULL, ev_ts, 3) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(12379813812177893520ULL, ev_ts, 4) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(12379813812177893520ULL, ev_ts, 5) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(12379813812177893520ULL, ev_ts, 6) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(12379813812177893520ULL, ev_ts, 7) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(12379813812177893520ULL, ev_ts, 8) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  // UINT64_MAX
+  assert(cb_cbor_encode_uint64(UINT64_MAX, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(UINT64_MAX, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(UINT64_MAX, ev_ts, 2) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(UINT64_MAX, ev_ts, 3) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(UINT64_MAX, ev_ts, 4) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(UINT64_MAX, ev_ts, 5) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(UINT64_MAX, ev_ts, 6) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(UINT64_MAX, ev_ts, 7) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_uint64(UINT64_MAX, ev_ts, 8) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+}
+
+void test_cb_cbor_encode_uint() {
+  uint8_t ev[9] = {0xFF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF};
+  // go to _cb_cbor_encode_uint8
+  assert(cb_cbor_encode_uint(0, ev, 9) == 1);
+  assert(cb_cbor_encode_uint(UINT8_MAX, ev, 9) == 2);
+  // go to _cb_cbor_encode_uint16 
+  assert(cb_cbor_encode_uint(256, ev, 9) == 3); // UINT8_MAX + 1
+  assert(cb_cbor_encode_uint(UINT16_MAX, ev, 9) == 3);
+  // go to _cb_cbor_encode_uint32
+  assert(cb_cbor_encode_uint(65536U, ev, 9) == 5);
+  assert(cb_cbor_encode_uint(UINT32_MAX, ev, 9) == 5); // UINT8_MAX + 1
+  // go to _cb_cbor_encode_uint64
+  assert(cb_cbor_encode_uint(4294967296ULL, ev, 9) == 9); // UINT32_MAX + 1
+  assert(cb_cbor_encode_uint(UINT64_MAX, ev, 9) == 9);
+}
+
+// NEGINT
+void test_cb_cbor_encode_negint8() {
+  // 1 byte
+  uint8_t ev_one_byte[2] = {0xEF, 0xEF}; // encoded value
+  uint8_t min_one_byte[2] = {0x20, 0xEF}; // negative(0) == -1
+  uint8_t middle_one_byte[2] = {0x30, 0xEF}; // negative(15) == -16
+  uint8_t max_one_byte[2] = {0x37, 0xEF}; // negative(23) == -24
+  assert(cb_cbor_encode_negint8(0, ev_one_byte, 1) == 1);
+  assert(memcmp(min_one_byte, ev_one_byte, 2) == 0);
+  assert(cb_cbor_encode_negint8(16, ev_one_byte, 1) == 1);
+  assert(memcmp(middle_one_byte, ev_one_byte, 2) == 0);
+  assert(cb_cbor_encode_negint8(23, ev_one_byte, 1) == 1);
+  assert(memcmp(max_one_byte, ev_one_byte, 2) == 0);
+
+  // 2 bytes
+  uint8_t ev_two_byte[2] = {0xFF, 0xEF}; // encoded value
+  uint8_t min_two_byte[2] = {0x38, 0x18}; // negative(24) == -25
+  uint8_t middle_two_byte[2] = {0x38, 0xAB}; // negative(171) == -172
+  uint8_t max_two_byte[2] = {0x38, 0xFF};  // negative(UINT8_MAX) == -256
+
+  assert(cb_cbor_encode_negint8(24, ev_two_byte, 2) == 2);
+  assert(memcmp(min_two_byte, ev_two_byte, 2) == 0);
+  assert(cb_cbor_encode_negint8(171, ev_two_byte, 2) == 2);
+  assert(memcmp(middle_two_byte, ev_two_byte, 2) == 0);
+  assert(cb_cbor_encode_negint8(UINT8_MAX, ev_two_byte, 2) == 2);
+  assert(memcmp(max_two_byte, ev_two_byte, 2) == 0);
+
+  // Size tests
+  uint8_t ev_ts[2] = {0xFF, 0xEF}; // encoded value
+  uint8_t no_change[2] = {0xFF, 0xEF};
+  // 0
+  assert(cb_cbor_encode_negint8(0, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 2) == 0);
+  // 16
+  assert(cb_cbor_encode_uint8(16, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 2) == 0);
+  // 23
+  assert(cb_cbor_encode_uint8(23, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 2) == 0);
+  // 24
+  assert(cb_cbor_encode_negint8(24, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 2) == 0);
+  assert(cb_cbor_encode_negint8(24, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 2) == 0);
+  // 171
+  assert(cb_cbor_encode_negint8(171, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 2) == 0);
+  assert(cb_cbor_encode_negint8(171, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 2) == 0);
+  // UINT8_MAX
+  assert(cb_cbor_encode_negint8(UINT8_MAX, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 2) == 0);
+  assert(cb_cbor_encode_negint8(UINT8_MAX, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 2) == 0);
+}
+
+void test_cb_cbor_encode_negint16() {
+  // encoded value
+  uint8_t ev[3] = {0xFF, 0xEF, 0xEF};
+  // CBOR(0x390100) == negative(UINT8_MAX + 1) == -257
+  uint8_t min[3] = {0x39, 0x01, 0x00};
+  // CBOR(0x39ABCD) == negative(43981) == -43982
+  uint8_t middle[3] = {0x39, 0xAB, 0xCD};
+  // CBOR(0x39FFFF) == negative(UINT16_MAX) == -UINT16_MAX - 1
+  uint8_t max[3] = {0x39, 0xFF, 0xFF};
+
+  assert(cb_cbor_encode_negint16(256, ev, 3) == 3);
+  assert(memcmp(min, ev, 3) == 0);
+  assert(cb_cbor_encode_negint16(43981, ev, 3) == 3);
+  assert(memcmp(middle, ev, 3) == 0);
+  assert(cb_cbor_encode_negint16(UINT16_MAX, ev, 3) == 3);
+  assert(memcmp(max, ev, 3) == 0);
+
+  // Size tests
+  uint8_t ev_ts[3] = {0xFF, 0xEF, 0xEF}; // encoded value
+  uint8_t no_change[3] = {0xFF, 0xEF, 0xEF};
+  // UINT8_MAX + 1 == 256
+  assert(cb_cbor_encode_negint16(256, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 3) == 0);
+  assert(cb_cbor_encode_negint16(256, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 3) == 0);
+  assert(cb_cbor_encode_negint16(256, ev_ts, 2) == 0);
+  assert(memcmp(no_change, ev_ts, 3) == 0);
+  // 43981
+  assert(cb_cbor_encode_negint16(43981, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 3) == 0);
+  assert(cb_cbor_encode_negint16(43981, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 3) == 0);
+  assert(cb_cbor_encode_negint16(43981, ev_ts, 2) == 0);
+  assert(memcmp(no_change, ev_ts, 3) == 0);
+  // UINT16_MAX
+  assert(cb_cbor_encode_negint16(UINT16_MAX, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 3) == 0);
+  assert(cb_cbor_encode_negint16(UINT16_MAX, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 3) == 0);
+  assert(cb_cbor_encode_negint16(UINT16_MAX, ev_ts, 2) == 0);
+  assert(memcmp(no_change, ev_ts, 3) == 0);
+}
+
+void test_cb_cbor_encode_negint32() {
+  // encoded value
+  uint8_t ev[5] = {0xFF, 0xEF, 0xEF, 0xEF, 0xEF};
+  // CBOR(0x3A00010000) == negative(UINT16_MAX + 1) == -65537
+  uint8_t min[5] = {0x3A, 0x00, 0x01, 0x00, 0x00};
+  // CBOR(0x3AABCD1234) == negative(2882343476) == -2882343477
+  uint8_t middle[5] = {0x3A, 0xAB, 0xCD, 0x12, 0x34};
+  // CBOR(0x3AFFFFFFFF) == negative(UINT32_MAX) == -UINT32_MAX - 1
+  uint8_t max[5] = {0x3A, 0xFF, 0xFF, 0xFF, 0xFF};
+
+  assert(cb_cbor_encode_negint32(65536U, ev, 5) == 5);
+  assert(memcmp(min, ev, 5) == 0);
+  assert(cb_cbor_encode_negint32(2882343476U, ev, 5) == 5);
+  assert(memcmp(middle, ev, 5) == 0);
+  assert(cb_cbor_encode_negint32(UINT32_MAX, ev, 5) == 5);
+  assert(memcmp(max, ev, 5) == 0);
+
+  // Size tests
+  uint8_t ev_ts[5] = {0xFF, 0xEF, 0xEF, 0xEF, 0xEF}; // encoded value
+  uint8_t no_change[5] = {0xFF, 0xEF, 0xEF, 0xEF, 0xEF};
+  // UINT16_MAX + 1 == 65536
+  assert(cb_cbor_encode_negint32(65536U, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_negint32(65536U, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_negint32(65536U, ev_ts, 2) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_negint32(65536U, ev_ts, 3) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_negint32(65536U, ev_ts, 4) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  // 2882343476
+  assert(cb_cbor_encode_negint32(2882343476U, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_negint32(2882343476U, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_negint32(2882343476U, ev_ts, 2) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_negint32(2882343476U, ev_ts, 3) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_negint32(2882343476U, ev_ts, 4) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  // UINT32_MAX
+  assert(cb_cbor_encode_negint32(UINT32_MAX, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_negint32(UINT32_MAX, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_negint32(UINT32_MAX, ev_ts, 2) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_negint32(UINT32_MAX, ev_ts, 3) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+  assert(cb_cbor_encode_negint32(UINT32_MAX, ev_ts, 4) == 0);
+  assert(memcmp(no_change, ev_ts, 5) == 0);
+
+}
+
+void test_cb_cbor_encode_negint64() {
+  // encoded value
+  uint8_t ev[9] = {0xFF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF};
+  // CBOR(0x3B0000000100000000) == negative(UINT32_MAX + 1) == -4294967297
+  uint8_t min[9] = {0x3B, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00};
+  // CBOR(0x3BABCD123434567890) == negative(12379813812177893520)
+  uint8_t middle[9] = {0x3B, 0xAB, 0xCD, 0xEF, 0x12, 0x34, 0x56, 0x78, 0x90};
+  // CBOR(0x3BFFFFFFFFFFFFFFFF) == negative(UINT64_MAX) 
+  uint8_t max[9] = {0x3B, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+  
+  assert(cb_cbor_encode_negint64(4294967296ULL, ev, 9) == 9);
+  assert(memcmp(min, ev, 9) == 0);
+  assert(cb_cbor_encode_negint64(12379813812177893520ULL, ev, 9) == 9);
+  assert(memcmp(middle, ev, 9) == 0);
+  assert(cb_cbor_encode_negint64(UINT64_MAX, ev, 9) == 9);
+  assert(memcmp(max, ev, 9) == 0);
+
+  // Size tests
+  uint8_t ev_ts[9] = {0xFF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF};
+  uint8_t no_change[9] = {0xFF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF};
+  // UINT32_MAX + 1 == 4294967296
+  assert(cb_cbor_encode_negint64(4294967296ULL, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(4294967296ULL, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(4294967296ULL, ev_ts, 2) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(4294967296ULL, ev_ts, 3) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(4294967296ULL, ev_ts, 4) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(4294967296ULL, ev_ts, 5) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(4294967296ULL, ev_ts, 6) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(4294967296ULL, ev_ts, 7) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(4294967296ULL, ev_ts, 8) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  // 2882343476
+  assert(cb_cbor_encode_negint64(12379813812177893520ULL, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(12379813812177893520ULL, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(12379813812177893520ULL, ev_ts, 2) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(12379813812177893520ULL, ev_ts, 3) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(12379813812177893520ULL, ev_ts, 4) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(12379813812177893520ULL, ev_ts, 5) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(12379813812177893520ULL, ev_ts, 6) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(12379813812177893520ULL, ev_ts, 7) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(12379813812177893520ULL, ev_ts, 8) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  // UINT64_MAX
+  assert(cb_cbor_encode_negint64(UINT64_MAX, ev_ts, 0) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(UINT64_MAX, ev_ts, 1) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(UINT64_MAX, ev_ts, 2) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(UINT64_MAX, ev_ts, 3) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(UINT64_MAX, ev_ts, 4) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(UINT64_MAX, ev_ts, 5) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(UINT64_MAX, ev_ts, 6) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(UINT64_MAX, ev_ts, 7) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+  assert(cb_cbor_encode_negint64(UINT64_MAX, ev_ts, 8) == 0);
+  assert(memcmp(no_change, ev_ts, 9) == 0);
+}
+
+void test_cb_cbor_encode_negint() {
+  uint8_t ev[9] = {0xFF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF, 0xEF};
+  // go to _cb_cbor_encode_negint8
+  assert(cb_cbor_encode_negint(0, ev, 9) == 1);
+  assert(cb_cbor_encode_negint(UINT8_MAX, ev, 9) == 2);
+  // go to _cb_cbor_encode_negint16 
+  assert(cb_cbor_encode_negint(256, ev, 9) == 3); // UINT8_MAX + 1
+  assert(cb_cbor_encode_negint(UINT16_MAX, ev, 9) == 3);
+  // go to _cb_cbor_encode_negint32
+  assert(cb_cbor_encode_negint(65536U, ev, 9) == 5);
+  assert(cb_cbor_encode_negint(UINT32_MAX, ev, 9) == 5); // UINT8_MAX + 1
+  // go to _cb_cbor_encode_negint64
+  assert(cb_cbor_encode_negint(4294967296ULL, ev, 9) == 9); // UINT32_MAX + 1
+  assert(cb_cbor_encode_negint(UINT64_MAX, ev, 9) == 9);
+}
+
+// TODO: criterion or cmocka
+int main() {
+  ///////////
+  // TESTS //
+  ///////////
+
+  // uint
+  test_cb_cbor_encode_uint8();
+  test_cb_cbor_encode_uint16();
+  test_cb_cbor_encode_uint32();
+  test_cb_cbor_encode_uint64();
+  test_cb_cbor_encode_uint();
+
+  // negint
+  test_cb_cbor_encode_negint8();
+  test_cb_cbor_encode_negint16();
+  test_cb_cbor_encode_negint32();
+  test_cb_cbor_encode_negint64();
+  test_cb_cbor_encode_negint();
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
<!---
  Provide a general summary of your changes in the Title above 
  Examples:
    - "feat(bloom): ..."
    - "fix(cbor): ..."
-->

## Description
This PR add the following public functions:
```c
// INT
ssize_t cb_cbor_encode_uint8(uint8_t v, uint8_t *ev, ssize_t size);

ssize_t cb_cbor_encode_uint16(uint16_t v, uint8_t *ev, ssize_t size);

ssize_t cb_cbor_encode_uint32(uint32_t v, uint8_t *ev, ssize_t size);

ssize_t cb_cbor_encode_uint64(uint64_t v, uint8_t *ev, ssize_t size);

ssize_t cb_cbor_encode_uint(uint64_t v, uint8_t *ev, ssize_t size);

// NEG INT
ssize_t cb_cbor_encode_negint8(uint8_t v, uint8_t *ev, ssize_t size);

ssize_t cb_cbor_encode_negint16(uint16_t v, uint8_t *ev, ssize_t size);

ssize_t cb_cbor_encode_negint32(uint32_t v, uint8_t *ev, ssize_t size);

ssize_t cb_cbor_encode_negint64(uint64_t v, uint8_t *ev, ssize_t size);

ssize_t cb_cbor_encode_negint(uint64_t v, uint8_t *ev, ssize_t size);
```
And these internal functions:

```c
static inline ssize_t _cb_cbor_encode_uint8(uint8_t v, uint8_t *ev,
                                            ssize_t size, uint8_t offset);

static inline ssize_t _cb_cbor_encode_uint16(uint16_t v, uint8_t *ev,
                                             ssize_t size, uint8_t offset);

static inline ssize_t _cb_cbor_encode_uint32(uint32_t v, uint8_t *ev,
                                             ssize_t size, uint8_t offset);

static inline ssize_t _cb_cbor_encode_uint64(uint64_t v, uint8_t *ev,
                                             ssize_t size, uint8_t offset);

static inline ssize_t _cb_cbor_encode_uint(uint64_t v, uint8_t *ev,
                                           ssize_t size, uint8_t offset);

```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We have to encode and decode CBOR, it's the ABCs of a database that will deal with CBOR.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Each function is tested in the test_fs.c file with <assert.h> library.

### macOS Monterey v12.3.1

1) 🌱 Environment

```console
abenhlal@cborgdb:~/cborg/build$ uname -v
Darwin Kernel Version 21.4.0: Fri Mar 18 00:45:05 PDT 2022; root:xnu-8020.101.4~15/RELEASE_X86_64
```

```console
abenhlal@cborgdb:~/cborg/build$ cmake --version
cmake version 3.22.3

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

```console
abenhlal@cborgdb:~/cborg/build$ gcc --version
Apple clang version 13.1.6 (clang-1316.0.21.2.3)
Target: x86_64-apple-darwin21.4.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```



2) ⚙️ Build and tests

```console
abenhlal@cborgdb:~/cborg/build$ cmake ..
-- The C compiler identification is AppleClang 13.1.6.13160021
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/cborgdb/code/cborgdb/cborg/build
abenhlal@cborgdb:~/cborg/build$ make
[  6%] Building C object CMakeFiles/cborg.dir/src/cb_cbor.c.o
[ 13%] Building C object CMakeFiles/cborg.dir/src/cb_endianness.c.o
[ 20%] Building C object CMakeFiles/cborg.dir/src/cb_fs.c.o
[ 26%] Building C object CMakeFiles/cborg.dir/src/cborg.c.o
/Users/cborgdb/code/cborgdb/cborg/src/cborg.c:14:14: warning: unused parameter 'argc' [-Wunused-parameter]
int main(int argc, char const *argv[]) {
             ^
/Users/cborgdb/code/cborgdb/cborg/src/cborg.c:14:32: warning: unused parameter 'argv' [-Wunused-parameter]
int main(int argc, char const *argv[]) {
                               ^
2 warnings generated.
[ 33%] Linking C executable cborg
[ 33%] Built target cborg
[ 40%] Building C object CMakeFiles/test_fs.dir/tests/test_fs.c.o
[ 46%] Building C object CMakeFiles/test_fs.dir/src/cb_fs.c.o
[ 53%] Linking C executable test_fs
[ 53%] Built target test_fs
[ 60%] Building C object CMakeFiles/test_endianness.dir/tests/test_endianness.c.o
[ 66%] Building C object CMakeFiles/test_endianness.dir/src/cb_endianness.c.o
[ 73%] Linking C executable test_endianness
[ 73%] Built target test_endianness
[ 80%] Building C object CMakeFiles/test_cbor.dir/tests/test_cbor.c.o
[ 86%] Building C object CMakeFiles/test_cbor.dir/src/cb_cbor.c.o
[ 93%] Building C object CMakeFiles/test_cbor.dir/src/cb_endianness.c.o
[100%] Linking C executable test_cbor
[100%] Built target test_cbor
abenhlal@cborgdb:~/cborg/build$ make test
Running tests...
Test project /Users/cborgdb/code/cborgdb/cborg/build
    Start 1: test_fs
1/3 Test #1: test_fs ..........................   Passed    0.00 sec
    Start 2: test_endianness
2/3 Test #2: test_endianness ..................   Passed    0.00 sec
    Start 3: test_cbor
3/3 Test #3: test_cbor ........................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 3

Total Test time (real) =   0.02 sec
```

### Debian GNU/Linux 11 (bullseye)

1) 🌱 Environment

```console
abenhlal@cborgdb-01:~/cborg/build$ uname -a
Linux cborgdb-01 5.10.0-11-amd64 #1 SMP Debian 5.10.92-1 (2022-01-18) x86_64 GNU/Linux
```

```console
abenhlal@cborgdb-01:~/cborg/build$ cmake --version
cmake version 3.18.4

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

```console
abenhlal@cborgdb-01:~/cborg/build$ gcc --version
gcc (Debian 10.2.1-6) 10.2.1 20210110
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

2) ⚙️ Build and tests

```console
abenhlal@cborgdb-01:~/cborg/build$ cmake ..
-- The C compiler identification is GNU 10.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Check if the system is big endian
-- Searching 16 bit integer
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of unsigned short
-- Check size of unsigned short - done
-- Searching 16 bit integer - Using unsigned short
-- Check if the system is big endian - little endian
-- Configuring done
-- Generating done
-- Build files have been written to: /home/abenhlal/cborg/build
abenhlal@cborgdb-01:~/cborg/build$ make
[  6%] Building C object CMakeFiles/test_cbor.dir/tests/test_cbor.c.o
[ 13%] Building C object CMakeFiles/test_cbor.dir/src/cb_cbor.c.o
[ 20%] Building C object CMakeFiles/test_cbor.dir/src/cb_endianness.c.o
[ 26%] Linking C executable test_cbor
[ 26%] Built target test_cbor
Scanning dependencies of target test_fs
[ 33%] Building C object CMakeFiles/test_fs.dir/tests/test_fs.c.o
[ 40%] Building C object CMakeFiles/test_fs.dir/src/cb_fs.c.o
[ 46%] Linking C executable test_fs
[ 46%] Built target test_fs
Scanning dependencies of target cborg
[ 53%] Building C object CMakeFiles/cborg.dir/src/cb_cbor.c.o
[ 60%] Building C object CMakeFiles/cborg.dir/src/cb_endianness.c.o
[ 66%] Building C object CMakeFiles/cborg.dir/src/cb_fs.c.o
[ 73%] Building C object CMakeFiles/cborg.dir/src/cborg.c.o
/home/abenhlal/cborg/src/cborg.c: In function ‘main’:
/home/abenhlal/cborg/src/cborg.c:14:14: warning: unused parameter ‘argc’ [-Wunused-parameter]
   14 | int main(int argc, char const *argv[]) {
      |          ~~~~^~~~
/home/abenhlal/cborg/src/cborg.c:14:32: warning: unused parameter ‘argv’ [-Wunused-parameter]
   14 | int main(int argc, char const *argv[]) {
      |                    ~~~~~~~~~~~~^~~~~~
[ 80%] Linking C executable cborg
[ 80%] Built target cborg
Scanning dependencies of target test_endianness
[ 86%] Building C object CMakeFiles/test_endianness.dir/tests/test_endianness.c.o
[ 93%] Building C object CMakeFiles/test_endianness.dir/src/cb_endianness.c.o
[100%] Linking C executable test_endianness
[100%] Built target test_endianness
abenhlal@cborgdb-01:~/cborg/build$ make test
Running tests...
Test project /home/abenhlal/cborg/build
    Start 1: test_fs
1/3 Test #1: test_fs ..........................   Passed    0.00 sec
    Start 2: test_endianness
2/3 Test #2: test_endianness ..................   Passed    0.00 sec
    Start 3: test_cbor
3/3 Test #3: test_cbor ........................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 3

Total Test time (real) =   0.01 sec
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
