### PR TITLE
feat(ops): add CRUD operation functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(cborg VERSION 0.1.0 LANGUAGES C)
 
 # BUILD
 set(CMAKE_C_FLAGS "-std=c99 -Wall -Wextra -pedantic")
-
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer")
 include(TestBigEndian)
 test_big_endian(IS_BIG_ENDIAN)
 if(IS_BIG_ENDIAN)
@@ -26,6 +26,8 @@ add_executable(test_endianness "${CMAKE_SOURCE_DIR}/tests/test_endianness.c" "${
 add_test(NAME test_endianness COMMAND test_endianness)
 add_executable(test_cb_cbor_int "${CMAKE_SOURCE_DIR}/tests/test_cb_cbor_int.c" "${CMAKE_SOURCE_DIR}/src/cb_cbor_int.c" "${CMAKE_SOURCE_DIR}/src/cb_endianness.c")
 add_test(NAME test_cb_cbor_int COMMAND test_cb_cbor_int)
+add_executable(test_cb_cbor_simple "${CMAKE_SOURCE_DIR}/tests/test_cb_cbor_simple.c" "${CMAKE_SOURCE_DIR}/src/cb_cbor_simple.c")
+add_test(NAME test_cb_cbor_simple COMMAND test_cb_cbor_simple)
 
 # INSTALL CBORG
 install(TARGETS cborg DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,8 @@ add_executable(test_fs "${CMAKE_SOURCE_DIR}/tests/test_fs.c" "${CMAKE_SOURCE_DIR
 add_test(NAME test_fs COMMAND test_fs)
 add_executable(test_endianness "${CMAKE_SOURCE_DIR}/tests/test_endianness.c" "${CMAKE_SOURCE_DIR}/src/cb_endianness.c")
 add_test(NAME test_endianness COMMAND test_endianness)
-add_executable(test_cbor "${CMAKE_SOURCE_DIR}/tests/test_cbor.c" "${CMAKE_SOURCE_DIR}/src/cb_cbor.c" "${CMAKE_SOURCE_DIR}/src/cb_endianness.c")
-add_test(NAME test_cbor COMMAND test_cbor)
+add_executable(test_cb_cbor_int "${CMAKE_SOURCE_DIR}/tests/test_cb_cbor_int.c" "${CMAKE_SOURCE_DIR}/src/cb_cbor_int.c" "${CMAKE_SOURCE_DIR}/src/cb_endianness.c")
+add_test(NAME test_cb_cbor_int COMMAND test_cb_cbor_int)
 
 # INSTALL CBORG
 install(TARGETS cborg DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ add_executable(test_cb_cbor_int "${CMAKE_SOURCE_DIR}/tests/test_cb_cbor_int.c" "
 add_test(NAME test_cb_cbor_int COMMAND test_cb_cbor_int)
 add_executable(test_cb_cbor_simple "${CMAKE_SOURCE_DIR}/tests/test_cb_cbor_simple.c" "${CMAKE_SOURCE_DIR}/src/cb_cbor_simple.c")
 add_test(NAME test_cb_cbor_simple COMMAND test_cb_cbor_simple)
+add_executable(test_cb_ops "${CMAKE_SOURCE_DIR}/tests/test_cb_ops.c" "${CMAKE_SOURCE_DIR}/src/cb_ops.c" "${CMAKE_SOURCE_DIR}/src/cb_endianness.c" "${CMAKE_SOURCE_DIR}/src/cb_fs.c" "${CMAKE_SOURCE_DIR}/src/cb_cbor_int.c" "${CMAKE_SOURCE_DIR}/src/cb_cbor_simple.c")
+add_test(NAME test_cb_ops COMMAND test_cb_ops)
 
 # INSTALL CBORG
 install(TARGETS cborg DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/include/cb_cbor.h
+++ b/include/cb_cbor.h
@@ -6,29 +6,7 @@
 #ifndef _CB_CBOR_H
 #define _CB_CBOR_H
 
-#include <unistd.h>
-#include <stdint.h>
+#define CBOR_MT(ib) (ib >> 5)
+#define CBOR_AI(ib) (ib & 0x1F)
 
-// INT
-ssize_t cb_cbor_encode_uint8(uint8_t v, uint8_t *ev, ssize_t size);
-
-ssize_t cb_cbor_encode_uint16(uint16_t v, uint8_t *ev, ssize_t size);
-
-ssize_t cb_cbor_encode_uint32(uint32_t v, uint8_t *ev, ssize_t size);
-
-ssize_t cb_cbor_encode_uint64(uint64_t v, uint8_t *ev, ssize_t size);
-
-ssize_t cb_cbor_encode_uint(uint64_t v, uint8_t *ev, ssize_t size);
-
-// NEG INT
-ssize_t cb_cbor_encode_negint8(uint8_t v, uint8_t *ev, ssize_t size);
-
-ssize_t cb_cbor_encode_negint16(uint16_t v, uint8_t *ev, ssize_t size);
-
-ssize_t cb_cbor_encode_negint32(uint32_t v, uint8_t *ev, ssize_t size);
-
-ssize_t cb_cbor_encode_negint64(uint64_t v, uint8_t *ev, ssize_t size);
-
-ssize_t cb_cbor_encode_negint(uint64_t v, uint8_t *ev, ssize_t size);
-
-#endif // _CB_CBOR_H
+#endif // _CB_CBOR_INT_H

--- a/include/cb_cbor_int.h
+++ b/include/cb_cbor_int.h
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2021-present Adil Benhlal <abenhlal@cborgdb.com>
+ *
+ */
+
+#ifndef _CB_CBOR_INT_H
+#define _CB_CBOR_INT_H
+
+#include <unistd.h>
+#include <stdint.h>
+
+//////////////
+// ENCODING //
+//////////////
+
+// INT
+ssize_t cb_cbor_encode_uint8(uint8_t v, uint8_t *ev, ssize_t size);
+
+ssize_t cb_cbor_encode_uint16(uint16_t v, uint8_t *ev, ssize_t size);
+
+ssize_t cb_cbor_encode_uint32(uint32_t v, uint8_t *ev, ssize_t size);
+
+ssize_t cb_cbor_encode_uint64(uint64_t v, uint8_t *ev, ssize_t size);
+
+ssize_t cb_cbor_encode_uint(uint64_t v, uint8_t *ev, ssize_t size);
+
+// NEG INT
+ssize_t cb_cbor_encode_negint8(uint8_t v, uint8_t *ev, ssize_t size);
+
+ssize_t cb_cbor_encode_negint16(uint16_t v, uint8_t *ev, ssize_t size);
+
+ssize_t cb_cbor_encode_negint32(uint32_t v, uint8_t *ev, ssize_t size);
+
+ssize_t cb_cbor_encode_negint64(uint64_t v, uint8_t *ev, ssize_t size);
+
+ssize_t cb_cbor_encode_negint(uint64_t v, uint8_t *ev, ssize_t size);
+
+///////////////
+// ACCESSORS //
+///////////////
+
+int cb_cbor_get_uint(const uint8_t *item, uint64_t *value);
+
+int cb_cbor_get_uint_size(const uint8_t *item);
+
+///////////////
+// OPERATORS //
+///////////////
+
+int cb_cbor_int_eq(const uint8_t *a, const uint8_t *b);
+
+int cb_cbor_int_strict_eq(const uint8_t *a, const uint8_t *b);
+
+int cb_cbor_int_not_eq(const uint8_t *a, const uint8_t *b);
+
+int cb_cbor_int_strict_not_eq(const uint8_t *a, const uint8_t *b);
+
+int cb_cbor_int_lt(const uint8_t *a, const uint8_t *b);
+
+int cb_cbor_int_gt(const uint8_t *a, const uint8_t *b);
+
+int cb_cbor_int_lt_eq(const uint8_t *a, const uint8_t *b);
+
+int cb_cbor_int_gt_eq(const uint8_t *a, const uint8_t *b);
+
+#endif // _CB_CBOR_INT_H

--- a/include/cb_cbor_simple.h
+++ b/include/cb_cbor_simple.h
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2021-present Adil Benhlal <abenhlal@cborgdb.com>
+ *
+ */
+
+#ifndef _CB_CBOR_SIMPLE_H
+#define _CB_CBOR_SIMPLE_H
+
+#include <unistd.h>
+#include <stdint.h>
+
+//////////////
+// ENCODING //
+//////////////
+
+ssize_t cb_cbor_encode_null(uint8_t *ev, ssize_t size);
+
+#endif // _CB_CBOR_SIMPLE_H

--- a/include/cb_fs.h
+++ b/include/cb_fs.h
@@ -6,8 +6,6 @@
 #ifndef _CB_FS_H
 #define _CB_FS_H
 
-#include <stdlib.h>
-
 int cb_fs_mkdir(const char *path);
 
 int cb_fs_rmdir(const char *dir_path);
@@ -19,5 +17,9 @@ int cb_fs_remove(const char *path);
 int cb_fs_dir_exists(const char *path);
 
 int cb_fs_file_exists(const char *path);
+
+int cb_fs_open(const char *path);
+
+int cb_fs_close(int fd);
 
 #endif // _CB_FS_H

--- a/include/cb_ops.h
+++ b/include/cb_ops.h
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2021-present Adil Benhlal <abenhlal@cborgdb.com>
+ *
+ */
+
+#ifndef _CB_OPS_H
+#define _CB_OPS_H
+
+#include <unistd.h>
+#include <sys/types.h>
+
+ssize_t cb_ops_insert_one(int fd, const void *data, size_t data_size);
+
+off_t cb_ops_find_one(int fd, void *data, size_t data_size, off_t after_pos);
+
+int cb_ops_update_one(int fd, void *old, size_t old_size, void *new,
+                  size_t new_size, off_t after_pos);
+
+int cb_ops_update_all(int fd, void *old, size_t old_size, void *new,
+                  size_t new_size, off_t after_pos);
+
+int cb_ops_delete_one(int fd, void *data, size_t data_size);
+
+int cb_ops_delete_all(int fd, void *data, size_t data_size);
+
+#endif // _CB_OPS_H

--- a/src/cb_cbor_int.c
+++ b/src/cb_cbor_int.c
@@ -4,6 +4,7 @@
  */
 
 #include "cb_cbor.h"
+#include "cb_cbor_int.h"
 #include "cb_endianness.h"
 
 static inline ssize_t _cb_cbor_encode_uint8(uint8_t v, uint8_t *ev,
@@ -20,6 +21,18 @@ static inline ssize_t _cb_cbor_encode_uint64(uint64_t v, uint8_t *ev,
 
 static inline ssize_t _cb_cbor_encode_uint(uint64_t v, uint8_t *ev,
                                            ssize_t size, uint8_t offset);
+
+static inline uint8_t cb_cbor_get_uint8(const uint8_t *item);
+
+static inline uint16_t cb_cbor_get_uint16(const uint8_t *item);
+
+static inline uint32_t cb_cbor_get_uint32(const uint8_t *item);
+
+static inline uint64_t cb_cbor_get_uint64(const uint8_t *item);
+
+//////////////
+// ENCODING //
+//////////////
 
 // INT
 ssize_t cb_cbor_encode_uint8(uint8_t v, uint8_t *ev, ssize_t size) {
@@ -63,9 +76,106 @@ ssize_t cb_cbor_encode_negint(uint64_t v, uint8_t *ev, ssize_t size) {
   return _cb_cbor_encode_uint(v, ev, size, 0x20);
 }
 
+///////////////
+// ACCESSORS //
+///////////////
+
+int cb_cbor_get_uint(const uint8_t *item, uint64_t *value) {
+  uint8_t ai = CBOR_AI(*item);
+  if(ai < 24)
+    *value = ai;
+  else if (ai == 24)
+    *value = cb_cbor_get_uint8(item);
+  else if (ai == 25)
+    *value = cb_cbor_get_uint16(item);
+  else if (ai == 26)
+    *value = cb_cbor_get_uint32(item);
+  else if (ai == 27)
+    *value = cb_cbor_get_uint64(item);
+  else
+    return -1;
+  return 0;
+}
+
+int cb_cbor_get_uint_size(const uint8_t *item) {
+  uint8_t ai = CBOR_AI(*item);
+  if(ai < 24)
+    return 1;
+  else if (ai == 24)
+    return 2;
+  else if (ai == 25)
+    return 3;
+  else if (ai == 26)
+    return 5;
+  else if (ai == 27)
+    return 9;
+  else
+    return -1;
+}
+
+///////////////
+// OPERATORS //
+///////////////
+
+// TODO: Maybe use memcmp ?
+int cb_cbor_int_eq(const uint8_t *a, const uint8_t *b) {
+  uint64_t a_value, b_value;
+  if(CBOR_MT(*a) == CBOR_MT(*b)){
+    if((!cb_cbor_get_uint(a, &a_value)) && (!cb_cbor_get_uint(b, &b_value)))
+      return a_value == b_value;
+    else
+      return -1;
+  }
+  return 0;
+}
+
+int cb_cbor_int_strict_eq(const uint8_t *a, const uint8_t *b) {
+  if(CBOR_AI(*a) == CBOR_AI(*b))
+    return cb_cbor_int_eq(a, b);
+  return 0;
+}
+
+int cb_cbor_int_not_eq(const uint8_t *a, const uint8_t *b) {
+
+  return !cb_cbor_int_eq(a, b);
+}
+
+int cb_cbor_int_strict_not_eq(const uint8_t *a, const uint8_t *b) {
+  return !cb_cbor_int_strict_eq(a, b);
+}
+
+int cb_cbor_int_lt(const uint8_t *a, const uint8_t *b) {
+  uint64_t a_value, b_value;
+  uint8_t a_mt = CBOR_MT(*a);
+  uint8_t b_mt = CBOR_MT(*b);
+  if (a_mt == 0 && b_mt == 0) {
+    if((!cb_cbor_get_uint(a, &a_value)) && (!cb_cbor_get_uint(b, &b_value)))
+      return a_value < b_value;
+  } else if (a_mt == 1 && b_mt == 1) {
+    if((!cb_cbor_get_uint(a, &a_value)) && (!cb_cbor_get_uint(b, &b_value)))
+      return a_value > b_value;
+  } else {
+    return a_mt > b_mt;
+  }
+  return -1;
+}
+
+int cb_cbor_int_gt(const uint8_t *a, const uint8_t *b) {
+  return !cb_cbor_int_lt(a, b) && !cb_cbor_int_eq(a, b);
+}
+
+int cb_cbor_int_lt_eq(const uint8_t *a, const uint8_t *b) {
+  return cb_cbor_int_lt(a, b) || cb_cbor_int_eq(a, b);
+}
+
+int cb_cbor_int_gt_eq(const uint8_t *a, const uint8_t *b) {
+  return !cb_cbor_int_lt(a, b) || cb_cbor_int_eq(a, b);
+}
+
 //////////////
 // INTERNAL //
 //////////////
+
 static inline ssize_t _cb_cbor_encode_uint8(uint8_t v, uint8_t *ev,
                                             ssize_t size, uint8_t offset) {
   if (v < 24) {
@@ -136,4 +246,33 @@ static inline ssize_t _cb_cbor_encode_uint(uint64_t v, uint8_t *ev,
     return _cb_cbor_encode_uint32(v, ev, size, offset);
   else
     return _cb_cbor_encode_uint64(v, ev, size, offset);
+}
+
+static inline uint8_t cb_cbor_get_uint8(const uint8_t *item) {
+  uint8_t ai = CBOR_AI(*item);
+  return ai < 24 ? ai : item[1];
+}
+
+static inline uint16_t cb_cbor_get_uint16(const uint8_t *item) {
+#ifdef IS_BIG_ENDIAN
+  return *(item+1);
+#else
+  return cb_bswap16(*(item+1));
+#endif
+}
+
+static inline uint32_t cb_cbor_get_uint32(const uint8_t *item) {
+#ifdef IS_BIG_ENDIAN
+  return *(item+1);
+#else
+  return cb_bswap32(*(item+1));
+#endif
+}
+
+static inline uint64_t cb_cbor_get_uint64(const uint8_t *item) {
+#ifdef IS_BIG_ENDIAN
+  return *(item+1);
+#else
+  return cb_bswap64(*(item+1));
+#endif
 }

--- a/src/cb_cbor_simple.c
+++ b/src/cb_cbor_simple.c
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2021-present Adil Benhlal <abenhlal@cborgdb.com>
+ *
+ */
+
+#include "cb_cbor_simple.h"
+
+ssize_t cb_cbor_encode_null(uint8_t *ev, ssize_t size) {
+  if (size >= 1) {
+    *ev = 0xF6;
+    return 1;
+  }
+  return 0;
+}

--- a/src/cb_fs.c
+++ b/src/cb_fs.c
@@ -4,9 +4,9 @@
  */
 
 #ifdef __linux__
-// To avoid error compilation on DT_DIR and DT_REG 
+// To avoid error compilation on DT_DIR and DT_REG
 // Warning d_type in entry is not supported by all filesystem types
-#define _GNU_SOURCE 
+#define _GNU_SOURCE
 #include <linux/limits.h> // PATH_MAX
 #endif
 
@@ -48,16 +48,13 @@ int cb_fs_rmdir(const char *dir_path) {
 }
 
 int cb_fs_touch(const char *path) {
-  int fd = open(path, O_WRONLY | O_CREAT , 0644);
+  int fd = open(path, O_WRONLY | O_CREAT, 0644);
   if (fd < 0)
     return -1;
-  close(fd);
-  return 0;
+  return close(fd);
 }
 
-int cb_fs_remove(const char *path) {
-  return unlink(path);
-}
+int cb_fs_remove(const char *path) { return unlink(path); }
 
 int cb_fs_dir_exists(const char *path) {
   struct stat stats;
@@ -68,3 +65,7 @@ int cb_fs_file_exists(const char *path) {
   struct stat stats;
   return stat(path, &stats) == 0 && S_ISREG(stats.st_mode);
 }
+
+int cb_fs_open(const char *path) { return open(path, O_RDWR | O_CREAT, 0644); }
+
+int cb_fs_close(int fd) { return close(fd); }

--- a/src/cb_ops.c
+++ b/src/cb_ops.c
@@ -3,6 +3,8 @@
  *
  */
 
+#define _XOPEN_SOURCE 500
+
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/cb_ops.c
+++ b/src/cb_ops.c
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2021-present Adil Benhlal <abenhlal@cborgdb.com>
+ *
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include "cb_cbor_int.h"
+#include "cb_cbor_simple.h"
+#include "cb_ops.h"
+
+// Bad code to see performance improvement later :)
+
+// Simple insert (Like append) to the end of the file O(1) ;)
+ssize_t cb_ops_insert_one(int fd, const void *item, size_t item_size) {
+  struct stat s;
+  if (fstat(fd, &s) == 0)
+    return pwrite(fd, item, item_size, s.st_size);
+  return 0;
+}
+
+// Linear Search O(n/2)
+// return
+//  >0 : position found
+//  -2 = not found
+//  -1 = erreur -> errno
+off_t cb_ops_find_one(int fd, void *item, size_t item_size, off_t start_pos) {
+  int ret = 0;
+  uint8_t buf[9];
+  while ((ret = pread(fd, buf, 9, start_pos)) != 0) {
+    if (cb_cbor_int_eq(item, buf) == 1)
+      return start_pos;
+    int size_item_buf = cb_cbor_get_uint_size(buf);
+    // if (size_item_buf == -1) then item is null (0xF6) -> skip one byte
+    start_pos += (size_item_buf != -1 ? size_item_buf : 1);
+  }
+  return ret == 0 ? -2 : ret;
+}
+
+// Replace first item O(n/2)
+// Not atomic: If the execution goes wrong then the file becomes corrupted
+int cb_ops_update_one(int fd, void *old, size_t old_size, void *new,
+                  size_t new_size, off_t after_pos) {
+  off_t position;
+  if ((position = cb_ops_find_one(fd, old, old_size, after_pos)) >= 0) {
+    if (old_size > new_size) {
+      int ret = 0;
+      uint8_t tmp;
+      off_t cur = position + old_size;
+      // from position + old_size - 1 to the end
+      while ((ret = pread(fd, &tmp, 1, cur) > 0)) {
+        // TODO: How to handle the problem if pread or pwrite fails?
+        pwrite(fd, &tmp, 1, cur - (old_size - new_size));
+        cur++;
+      }
+      struct stat s;
+      fstat(fd, &s);
+      // truncate the end of file
+      ftruncate(fd, s.st_size - (old_size - new_size));
+    } else if (old_size < new_size) {
+      int ret = 0;
+      uint8_t tmp;
+      struct stat s;
+      fstat(fd, &s);
+      off_t cur = s.st_size - 1;
+      // from the end to the position + old_size - 1
+      while ((ret = pread(fd, &tmp, 1, cur) > 0)) {
+        if(cur < position + (off_t)old_size)
+          break;
+        // TODO: How to handle the problem if pread or pwrite fails?
+        pwrite(fd, &tmp, 1, cur + (new_size - old_size) );
+        cur--;
+      }
+    }
+    // write the item
+    return pwrite(fd, new, new_size, position);
+  }
+
+  return position;
+}
+
+int cb_ops_update_all(int fd, void *old, size_t old_size, void *new,
+                  size_t new_size, off_t after_pos) {
+  int ret;
+  while((ret = cb_ops_update_one(fd, old, old_size, new, new_size, after_pos)) > 0);
+  return ret;
+}
+
+int cb_ops_delete_one(int fd, void *item, size_t item_size) {
+  off_t position;
+  if ((position = cb_ops_find_one(fd, item, item_size, 0)) >= 0) {
+    int ret = 0;
+    uint8_t tmp;
+    off_t cur = position + item_size;
+    while ((ret = pread(fd, &tmp, 1, cur) > 0)) {
+      // TODO: How to handle the problem if pread or pwrite fails?
+      pwrite(fd, &tmp, 1, cur - item_size);
+      cur++;
+    }
+    struct stat s;
+    fstat(fd, &s);
+    ftruncate(fd, s.st_size - item_size);
+    return 1;
+  }
+  return position;
+}
+
+int cb_ops_delete_all(int fd, void *item, size_t item_size) {
+  int ret;
+  while((ret = cb_ops_delete_one(fd,item,item_size)) > 0);
+  return ret;
+}

--- a/tests/test_cb_cbor_int.c
+++ b/tests/test_cb_cbor_int.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "cb_cbor.h"
+#include "cb_cbor_int.h"
 
 // INT
 void test_cb_cbor_encode_uint8() {
@@ -510,6 +510,14 @@ void test_cb_cbor_encode_negint() {
   assert(cb_cbor_encode_negint(UINT64_MAX, ev, 9) == 9);
 }
 
+void test_cb_cbor_get_uint() {
+
+}
+
+void test_cb_cbor_get_uint_size() {
+
+}
+
 // TODO: criterion or cmocka
 int main() {
   ///////////
@@ -529,6 +537,9 @@ int main() {
   test_cb_cbor_encode_negint32();
   test_cb_cbor_encode_negint64();
   test_cb_cbor_encode_negint();
+
+  test_cb_cbor_get_uint();
+  test_cb_cbor_get_uint_size();
 
   return EXIT_SUCCESS;
 }

--- a/tests/test_cb_cbor_simple.c
+++ b/tests/test_cb_cbor_simple.c
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2021-present Adil Benhlal <abenhlal@cborgdb.com>
+ *
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "cb_cbor_simple.h"
+
+// INT
+void test_cb_cbor_encode_null() {
+  // TEST 1
+  // test with size == 0 (no change)
+  uint8_t ev_t1_s0[2] = {0xFF, 0xFF}; // encoded value
+  uint8_t expect_t1_s0[2] = {0xFF, 0xFF}; // [ null, 0xFF ]
+  assert(cb_cbor_encode_null(ev_t1_s0, 0) == 0);
+  assert(memcmp(expect_t1_s0, ev_t1_s0, 2) == 0);
+
+  // test with size == 1
+  uint8_t ev_t1_s1[2] = {0xFF, 0xFF}; // encoded value
+  uint8_t expect_t1_s1[2] = {0xF6, 0xFF}; // [ null, 0xFF ]
+  assert(cb_cbor_encode_null(ev_t1_s1, 1) == 1);
+  assert(memcmp(expect_t1_s1, ev_t1_s1, 2) == 0);
+
+  // test with size == 2
+  uint8_t ev_t1_s2[2] = {0xFF, 0xFF}; // encoded value
+  uint8_t expect_t1_s2[2] = {0xF6, 0xFF}; // [ null, 0xFF ]
+  assert(cb_cbor_encode_null(ev_t1_s2, 2) == 1);
+  assert(memcmp(expect_t1_s2, ev_t1_s2, 2) == 0);
+
+  // TEST 2 (same test with another end byte)
+  // test with size == 0 (no change)
+  uint8_t ev_t2_s0[2] = {0xFF, 0xAB}; // encoded value
+  uint8_t expect_t2_s0[2] = {0xFF, 0xAB}; // [ null, 0xAB ]
+  assert(cb_cbor_encode_null(ev_t2_s0, 0) == 0);
+  assert(memcmp(expect_t2_s0, ev_t2_s0, 2) == 0);
+
+  // test with size == 1
+  uint8_t ev_t2_s1[2] = {0xFF, 0xAB}; // encoded value
+  uint8_t expect_t2_s1[2] = {0xF6, 0xAB}; // [ null, 0xAB ]
+  assert(cb_cbor_encode_null(ev_t2_s1, 1) == 1);
+  assert(memcmp(expect_t2_s1, ev_t2_s1, 2) == 0);
+
+  // test with size == 2
+  uint8_t ev_t2_s2[2] = {0xFF, 0xAB}; // encoded value
+  uint8_t expect_t2_s2[2] = {0xF6, 0xAB}; // [ null, 0xAB ]
+  assert(cb_cbor_encode_null(ev_t2_s2, 2) == 1);
+  assert(memcmp(expect_t2_s2, ev_t2_s2, 2) == 0);
+
+}
+
+// TODO: criterion or cmocka
+int main() {
+  test_cb_cbor_encode_null();
+
+  return EXIT_SUCCESS;
+}

--- a/tests/test_cb_ops.c
+++ b/tests/test_cb_ops.c
@@ -1,0 +1,266 @@
+/**
+ * Copyright (c) 2021-present Adil Benhlal <abenhlal@cborgdb.com>
+ *
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include "cb_fs.h"
+#include "cb_cbor_int.h"
+#include "cb_ops.h"
+
+int fd_uint;
+int fd_negint;
+int fd_int;
+
+void init(){
+  fd_uint = open("./uint.cb", O_RDWR | O_CREAT | O_TRUNC, 0644);
+  assert(fd_uint > 0);
+  fd_negint = open("./negint.cb", O_RDWR | O_CREAT | O_TRUNC, 0644);
+  assert(fd_negint > 0);
+  fd_int = open("./int.cb", O_RDWR | O_CREAT | O_TRUNC, 0644);
+  assert(fd_int > 0);
+}
+
+void destroy() {
+  cb_fs_close(fd_uint);
+  cb_fs_close(fd_negint);
+  cb_fs_close(fd_int);
+}
+
+void test_cb_ops_insert_one() {
+  // UINT8
+  uint8_t ev_uint8[2];
+  ssize_t ev_uint8_size;
+
+  ev_uint8_size = cb_cbor_encode_uint8(23,ev_uint8,2);
+  assert(cb_ops_insert_one(fd_uint, ev_uint8, ev_uint8_size) == 1);
+  ev_uint8_size = cb_cbor_encode_uint8(255,ev_uint8,2);
+  assert(cb_ops_insert_one(fd_uint, ev_uint8, ev_uint8_size) == 2);
+  ev_uint8_size = cb_cbor_encode_uint8(0,ev_uint8,2);
+  assert(cb_ops_insert_one(fd_uint, ev_uint8, ev_uint8_size) == 1);
+  ev_uint8_size = cb_cbor_encode_uint8(24,ev_uint8,2);
+  assert(cb_ops_insert_one(fd_uint, ev_uint8, ev_uint8_size) == 2);
+
+  struct stat s_uint8;
+  assert(fstat(fd_uint, &s_uint8) == 0);
+  assert(s_uint8.st_size == 6);
+
+  // NEGINT8
+  uint8_t ev_negint8[2];
+  ssize_t ev_negint8_size;
+
+  ev_negint8_size = cb_cbor_encode_negint8(23,ev_negint8,2);
+  assert(cb_ops_insert_one(fd_negint, ev_negint8, ev_negint8_size) == 1);
+  ev_negint8_size = cb_cbor_encode_negint8(255,ev_negint8,2);
+  assert(cb_ops_insert_one(fd_negint, ev_negint8, ev_negint8_size) == 2);
+  ev_negint8_size = cb_cbor_encode_negint8(0,ev_negint8,2);
+  assert(cb_ops_insert_one(fd_negint, ev_negint8, ev_negint8_size) == 1);
+  ev_negint8_size = cb_cbor_encode_negint8(24,ev_negint8,2);
+  assert(cb_ops_insert_one(fd_negint, ev_negint8, ev_negint8_size) == 2);
+
+  struct stat s_negint8;
+  assert(fstat(fd_negint, &s_negint8) == 0);
+  assert(s_negint8.st_size == 6);
+
+  // INT8
+  uint8_t ev_int8[2];
+  ssize_t ev_int8_size;
+
+  ev_int8_size = cb_cbor_encode_uint8(23,ev_int8,2);
+  assert(cb_ops_insert_one(fd_int, ev_int8, ev_int8_size) == 1);
+  ev_int8_size = cb_cbor_encode_negint8(24,ev_int8,2);
+  assert(cb_ops_insert_one(fd_int, ev_int8, ev_int8_size) == 2);
+  ev_int8_size = cb_cbor_encode_uint8(255,ev_int8,2);
+  assert(cb_ops_insert_one(fd_int, ev_int8, ev_int8_size) == 2);
+  ev_int8_size = cb_cbor_encode_negint8(0,ev_int8,2);
+  assert(cb_ops_insert_one(fd_int, ev_int8, ev_int8_size) == 1);
+  ev_int8_size = cb_cbor_encode_uint8(0,ev_int8,2);
+  assert(cb_ops_insert_one(fd_int, ev_int8, ev_int8_size) == 1);
+  ev_int8_size = cb_cbor_encode_negint8(255,ev_int8,2);
+  assert(cb_ops_insert_one(fd_int, ev_int8, ev_int8_size) == 2);
+  ev_int8_size = cb_cbor_encode_uint8(24,ev_int8,2);
+  assert(cb_ops_insert_one(fd_int, ev_int8, ev_int8_size) == 2);
+  ev_int8_size = cb_cbor_encode_negint8(23,ev_int8,2);
+  assert(cb_ops_insert_one(fd_int, ev_int8, ev_int8_size) == 1);
+
+  struct stat s_int8;
+  assert(fstat(fd_int, &s_int8) == 0);
+  assert(s_int8.st_size == 12);
+}
+
+void test_cb_ops_find_one() {
+    // UINT8
+  uint8_t ev_uint8[2];
+  ssize_t ev_uint8_size;
+
+  ev_uint8_size = cb_cbor_encode_uint8(23,ev_uint8,2);
+  assert(cb_ops_find_one(fd_uint, ev_uint8, ev_uint8_size,0) >= 0);
+  ev_uint8_size = cb_cbor_encode_uint8(255,ev_uint8,2);
+  assert(cb_ops_find_one(fd_uint, ev_uint8, ev_uint8_size,0) >= 0);
+  ev_uint8_size = cb_cbor_encode_uint8(0,ev_uint8,2);
+  assert(cb_ops_find_one(fd_uint, ev_uint8, ev_uint8_size,0) >= 0);
+  ev_uint8_size = cb_cbor_encode_uint8(24,ev_uint8,2);
+  assert(cb_ops_find_one(fd_uint, ev_uint8, ev_uint8_size,0) >= 0);
+  // not found
+  ev_uint8_size = cb_cbor_encode_uint8(15,ev_uint8,2);
+  assert(cb_ops_find_one(fd_uint, ev_uint8, ev_uint8_size,0) == -2);
+  ev_uint8_size = cb_cbor_encode_uint8(150,ev_uint8,2);
+  assert(cb_ops_find_one(fd_uint, ev_uint8, ev_uint8_size,0) == -2);
+
+  struct stat s_uint8;
+  assert(fstat(fd_uint, &s_uint8) == 0);
+  assert(s_uint8.st_size == 6);
+
+  // NEGINT8
+  uint8_t ev_negint8[2];
+  ssize_t ev_negint8_size;
+
+  ev_negint8_size = cb_cbor_encode_negint8(23,ev_negint8,2);
+  assert(cb_ops_find_one(fd_negint, ev_negint8, ev_negint8_size,0) >= 0);
+  ev_negint8_size = cb_cbor_encode_negint8(255,ev_negint8,2);
+  assert(cb_ops_find_one(fd_negint, ev_negint8, ev_negint8_size,0) >= 0);
+  ev_negint8_size = cb_cbor_encode_negint8(0,ev_negint8,2);
+  assert(cb_ops_find_one(fd_negint, ev_negint8, ev_negint8_size,0) >= 0);
+  ev_negint8_size = cb_cbor_encode_negint8(24,ev_negint8,2);
+  assert(cb_ops_find_one(fd_negint, ev_negint8, ev_negint8_size,0) >= 0);
+  // not found
+  ev_negint8_size = cb_cbor_encode_negint8(15,ev_negint8,2);
+  assert(cb_ops_find_one(fd_negint, ev_negint8, ev_negint8_size,0) == -2);
+  ev_negint8_size = cb_cbor_encode_negint8(150,ev_negint8,2);
+  assert(cb_ops_find_one(fd_negint, ev_negint8, ev_negint8_size,0) == -2);
+
+  struct stat s_negint8;
+  assert(fstat(fd_negint, &s_negint8) == 0);
+  assert(s_negint8.st_size == 6);
+
+  // INT8
+  uint8_t ev_int8[2];
+  ssize_t ev_int8_size;
+
+  ev_int8_size = cb_cbor_encode_uint8(23,ev_int8,2);
+  assert(cb_ops_find_one(fd_int, ev_int8, ev_int8_size,0) >= 0);
+  ev_int8_size = cb_cbor_encode_negint8(24,ev_int8,2);
+  assert(cb_ops_find_one(fd_int, ev_int8, ev_int8_size,0) >= 0);
+  ev_int8_size = cb_cbor_encode_uint8(255,ev_int8,2);
+  assert(cb_ops_find_one(fd_int, ev_int8, ev_int8_size,0) >= 0);
+  ev_int8_size = cb_cbor_encode_negint8(0,ev_int8,2);
+  assert(cb_ops_find_one(fd_int, ev_int8, ev_int8_size,0) >= 0);
+  ev_int8_size = cb_cbor_encode_uint8(0,ev_int8,2);
+  assert(cb_ops_find_one(fd_int, ev_int8, ev_int8_size,0) >= 0);
+  ev_int8_size = cb_cbor_encode_negint8(255,ev_int8,2);
+  assert(cb_ops_find_one(fd_int, ev_int8, ev_int8_size,0) >= 0);
+  ev_int8_size = cb_cbor_encode_uint8(24,ev_int8,2);
+  assert(cb_ops_find_one(fd_int, ev_int8, ev_int8_size,0) >= 0);
+  ev_int8_size = cb_cbor_encode_negint8(23,ev_int8,2);
+  assert(cb_ops_find_one(fd_int, ev_int8, ev_int8_size,0) >= 0);
+
+  // not found
+  ev_int8_size = cb_cbor_encode_negint8(15,ev_int8,2);
+  assert(cb_ops_find_one(fd_int, ev_int8, ev_int8_size,0) == -2);
+  ev_int8_size = cb_cbor_encode_negint8(150,ev_int8,2);
+  assert(cb_ops_find_one(fd_int, ev_int8, ev_int8_size,0) == -2);
+  ev_int8_size = cb_cbor_encode_uint8(15,ev_int8,2);
+  assert(cb_ops_find_one(fd_int, ev_int8, ev_int8_size,0) == -2);
+  ev_int8_size = cb_cbor_encode_uint8(150,ev_int8,2);
+  assert(cb_ops_find_one(fd_int, ev_int8, ev_int8_size,0) == -2);
+
+  struct stat s_int8;
+  assert(fstat(fd_int, &s_int8) == 0);
+  assert(s_int8.st_size == 12);
+
+}
+
+void test_cb_ops_update_one() {
+    // UINT8
+  uint8_t old_ev_uint8[2];
+  ssize_t old_ev_uint8_size;
+  uint8_t new_ev_uint8[2];
+  ssize_t new_ev_uint8_size;
+  struct stat s_uint8;
+
+  old_ev_uint8_size = cb_cbor_encode_uint8(23,old_ev_uint8,2);
+  new_ev_uint8_size = cb_cbor_encode_uint8(0,new_ev_uint8,2);
+  assert(cb_ops_update_one(fd_uint, old_ev_uint8, old_ev_uint8_size, new_ev_uint8, new_ev_uint8_size, 0) > 0);
+  assert(fstat(fd_uint, &s_uint8) == 0);
+  assert(s_uint8.st_size == 6);
+
+  old_ev_uint8_size = cb_cbor_encode_uint8(24,old_ev_uint8,2);
+  new_ev_uint8_size = cb_cbor_encode_uint8(23,new_ev_uint8,2);
+  assert(cb_ops_update_one(fd_uint, old_ev_uint8, old_ev_uint8_size, new_ev_uint8, new_ev_uint8_size, 0) > 0);
+  assert(fstat(fd_uint, &s_uint8) == 0);
+  assert(s_uint8.st_size == 5);
+  
+  old_ev_uint8_size = cb_cbor_encode_uint8(23,old_ev_uint8,2);
+  new_ev_uint8_size = cb_cbor_encode_uint8(255,new_ev_uint8,2);
+  assert(cb_ops_update_one(fd_uint, old_ev_uint8, old_ev_uint8_size, new_ev_uint8, new_ev_uint8_size, 0) > 0);
+  assert(fstat(fd_uint, &s_uint8) == 0);
+  assert(s_uint8.st_size == 6);
+}
+
+void test_cb_ops_update_all() {
+  // UINT8
+  uint8_t old_ev_uint8[2];
+  ssize_t old_ev_uint8_size;
+  uint8_t new_ev_uint8[2];
+  ssize_t new_ev_uint8_size;
+  struct stat s_uint8;
+
+  old_ev_uint8_size = cb_cbor_encode_uint8(255,old_ev_uint8,2);
+  new_ev_uint8_size = cb_cbor_encode_uint8(23,new_ev_uint8,2);
+  assert(cb_ops_update_all(fd_uint, old_ev_uint8, old_ev_uint8_size, new_ev_uint8, new_ev_uint8_size, 0) != -1);
+  assert(fstat(fd_uint, &s_uint8) == 0);
+  assert(s_uint8.st_size == 4);
+
+  old_ev_uint8_size = cb_cbor_encode_uint8(0,old_ev_uint8,2);
+  new_ev_uint8_size = cb_cbor_encode_uint8(24,new_ev_uint8,2);
+  assert(cb_ops_update_all(fd_uint, old_ev_uint8, old_ev_uint8_size, new_ev_uint8, new_ev_uint8_size, 0) != -1);
+  assert(fstat(fd_uint, &s_uint8) == 0);
+  assert(s_uint8.st_size == 6);
+}
+
+void test_cb_ops_delete_one() {
+  // UINT8
+  uint8_t ev_uint8[2];
+  ssize_t ev_uint8_size;
+  struct stat s_uint8;
+
+  ev_uint8_size = cb_cbor_encode_uint8(23,ev_uint8,2);
+  assert(cb_ops_delete_one(fd_uint, ev_uint8, ev_uint8_size) != -1);
+  assert(fstat(fd_uint, &s_uint8) == 0);
+  assert(s_uint8.st_size == 5);
+}
+
+void test_cb_ops_delete_all() {
+  // UINT8
+  uint8_t ev_uint8[2];
+  ssize_t ev_uint8_size;
+  struct stat s_uint8;
+
+  ev_uint8_size = cb_cbor_encode_uint8(23,ev_uint8,2);
+  assert(cb_ops_delete_all(fd_uint, ev_uint8, ev_uint8_size) != -1);
+  assert(fstat(fd_uint, &s_uint8) == 0);
+  assert(s_uint8.st_size == 4);
+}
+
+// TODO: criterion or cmocka
+int main() {
+  init();
+
+  // TESTS
+  test_cb_ops_insert_one();
+  test_cb_ops_find_one();
+  test_cb_ops_update_one();
+  test_cb_ops_update_all();
+  test_cb_ops_delete_one();
+  test_cb_ops_delete_all();
+  
+  destroy();
+
+  return EXIT_SUCCESS;
+}

--- a/tests/test_fs.c
+++ b/tests/test_fs.c
@@ -8,9 +8,12 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
 
 #include "cb_fs.h"
 
+#define FAKE_FILE_OPEN "./fake_file_open"
 #define FAKE_DIRECTORY "./fake_directory"
 #define FAKE_FILE "./fake_directory/fake_file"
 #define FAKE_FILE_REMOVE "./fake_directory/fake_file_remove"
@@ -58,6 +61,17 @@ void test_cb_fs_rmdir() {
   assert(cb_fs_rmdir(FAKE_SUB_DIRECTORY_REMOVE) == 0);
 }
 
+void test_cb_fs_open_close() {
+  // test_cb_fs_open
+  int fd = cb_fs_open(FAKE_FILE_OPEN);
+  assert(fd != -1);
+  assert(fcntl(fd, F_GETFD) != -1);
+  
+  // test_cb_fs_close
+  close(fd);
+  assert(fcntl(fd, F_GETFD) == -1);
+}
+
 // TODO: criterion or cmocka
 int main() {
   init();
@@ -69,6 +83,7 @@ int main() {
   test_cb_fs_file_exists();
   test_cb_fs_remove();
   test_cb_fs_rmdir();
+  test_cb_fs_open_close();
 
   destroy();
 


### PR DESCRIPTION
<!---
  Provide a general summary of your changes in the Title above 
  Examples:
    - "feat(bloom): ..."
    - "fix(cbor): ..."
-->

## Description
This PR add the following public functions:
```c
ssize_t cb_ops_insert_one(int fd, const void *data, size_t data_size);

off_t cb_ops_find_one(int fd, void *data, size_t data_size, off_t after_pos);

int cb_ops_update_one(int fd, void *old, size_t old_size, void *new,
                  size_t new_size, off_t after_pos);

int cb_ops_update_all(int fd, void *old, size_t old_size, void *new,
                  size_t new_size, off_t after_pos);

int cb_ops_delete_one(int fd, void *data, size_t data_size);

int cb_ops_delete_all(int fd, void *data, size_t data_size);
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We have to perform CRUD operations on file CBOR.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Each function is tested in the test_cb_ops.c file with <assert.h> library.

### macOS Monterey v12.3.1

1) 🌱 Environment

```console
abenhlal@cborgdb:~/cborg/build$ uname -v
Darwin Kernel Version 21.4.0: Fri Mar 18 00:45:05 PDT 2022; root:xnu-8020.101.4~15/RELEASE_X86_64
```

```console
abenhlal@cborgdb:~/cborg/build$ cmake --version
cmake version 3.22.3

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

```console
abenhlal@cborgdb:~/cborg/build$ gcc --version
Apple clang version 13.1.6 (clang-1316.0.21.2.3)
Target: x86_64-apple-darwin21.4.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

2) ⚙️ Build and tests

```console
abenhlal@cborgdb:~/cborg/build$ cmake ..
-- The C compiler identification is AppleClang 13.1.6.13160021
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/cborgdb/code/cborgdb/cborg/build
abenhlal@cborgdb:~/cborg/build$ make
[  3%] Building C object CMakeFiles/cborg.dir/src/cb_cbor_int.c.o
[  7%] Building C object CMakeFiles/cborg.dir/src/cb_cbor_simple.c.o
[ 11%] Building C object CMakeFiles/cborg.dir/src/cb_endianness.c.o
[ 14%] Building C object CMakeFiles/cborg.dir/src/cb_fs.c.o
[ 18%] Building C object CMakeFiles/cborg.dir/src/cb_ops.c.o
/Users/cborgdb/code/cborgdb/cborg/src/cb_ops.c:30:50: warning: unused parameter 'item_size' [-Wunused-parameter]
off_t cb_ops_find_one(int fd, void *item, size_t item_size, off_t start_pos) {
                                                 ^
1 warning generated.
[ 22%] Building C object CMakeFiles/cborg.dir/src/cborg.c.o
/Users/cborgdb/code/cborgdb/cborg/src/cborg.c:14:14: warning: unused parameter 'argc' [-Wunused-parameter]
int main(int argc, char const *argv[]) {
             ^
/Users/cborgdb/code/cborgdb/cborg/src/cborg.c:14:32: warning: unused parameter 'argv' [-Wunused-parameter]
int main(int argc, char const *argv[]) {
                               ^
2 warnings generated.
[ 25%] Linking C executable cborg
[ 25%] Built target cborg
[ 29%] Building C object CMakeFiles/test_fs.dir/tests/test_fs.c.o
[ 33%] Building C object CMakeFiles/test_fs.dir/src/cb_fs.c.o
[ 37%] Linking C executable test_fs
[ 37%] Built target test_fs
[ 40%] Building C object CMakeFiles/test_endianness.dir/tests/test_endianness.c.o
[ 44%] Building C object CMakeFiles/test_endianness.dir/src/cb_endianness.c.o
[ 48%] Linking C executable test_endianness
[ 48%] Built target test_endianness
[ 51%] Building C object CMakeFiles/test_cb_cbor_int.dir/tests/test_cb_cbor_int.c.o
[ 55%] Building C object CMakeFiles/test_cb_cbor_int.dir/src/cb_cbor_int.c.o
[ 59%] Building C object CMakeFiles/test_cb_cbor_int.dir/src/cb_endianness.c.o
[ 62%] Linking C executable test_cb_cbor_int
[ 62%] Built target test_cb_cbor_int
[ 66%] Building C object CMakeFiles/test_cb_cbor_simple.dir/tests/test_cb_cbor_simple.c.o
[ 70%] Building C object CMakeFiles/test_cb_cbor_simple.dir/src/cb_cbor_simple.c.o
[ 74%] Linking C executable test_cb_cbor_simple
[ 74%] Built target test_cb_cbor_simple
[ 77%] Building C object CMakeFiles/test_cb_ops.dir/tests/test_cb_ops.c.o
[ 81%] Building C object CMakeFiles/test_cb_ops.dir/src/cb_ops.c.o
/Users/cborgdb/code/cborgdb/cborg/src/cb_ops.c:30:50: warning: unused parameter 'item_size' [-Wunused-parameter]
off_t cb_ops_find_one(int fd, void *item, size_t item_size, off_t start_pos) {
                                                 ^
1 warning generated.
[ 85%] Building C object CMakeFiles/test_cb_ops.dir/src/cb_endianness.c.o
[ 88%] Building C object CMakeFiles/test_cb_ops.dir/src/cb_fs.c.o
[ 92%] Building C object CMakeFiles/test_cb_ops.dir/src/cb_cbor_int.c.o
[ 96%] Building C object CMakeFiles/test_cb_ops.dir/src/cb_cbor_simple.c.o
[100%] Linking C executable test_cb_ops
[100%] Built target test_cb_ops
abenhlal@cborgdb:~/cborg/build$ make test
Running tests...
Test project /Users/cborgdb/code/cborgdb/cborg/build
    Start 1: test_fs
1/5 Test #1: test_fs ..........................   Passed    0.00 sec
    Start 2: test_endianness
2/5 Test #2: test_endianness ..................   Passed    0.00 sec
    Start 3: test_cb_cbor_int
3/5 Test #3: test_cb_cbor_int .................   Passed    0.00 sec
    Start 4: test_cb_cbor_simple
4/5 Test #4: test_cb_cbor_simple ..............   Passed    0.00 sec
    Start 5: test_cb_ops
5/5 Test #5: test_cb_ops ......................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 5

Total Test time (real) =   0.02 sec
```

### Debian GNU/Linux 11 (bullseye)

1) 🌱 Environment

```console
abenhlal@cborgdb-01:~/cborg/build$ uname -a
Linux cborgdb-01 5.10.0-11-amd64 #1 SMP Debian 5.10.92-1 (2022-01-18) x86_64 GNU/Linux
```

```console
abenhlal@cborgdb-01:~/cborg/build$ cmake --version
cmake version 3.18.4

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

```console
abenhlal@cborgdb-01:~/cborg/build$ gcc --version
gcc (Debian 10.2.1-6) 10.2.1 20210110
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

2) ⚙️ Build and tests

```console
abenhlal@cborgdb-01:~/cborg/build$ cmake ..
-- The C compiler identification is GNU 10.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Check if the system is big endian
-- Searching 16 bit integer
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of unsigned short
-- Check size of unsigned short - done
-- Searching 16 bit integer - Using unsigned short
-- Check if the system is big endian - little endian
-- Configuring done
-- Generating done
-- Build files have been written to: /home/abenhlal/cborg/build
abenhlal@cborgdb-01:~/cborg/build$ make
Scanning dependencies of target test_cb_cbor_simple
[  3%] Building C object CMakeFiles/test_cb_cbor_simple.dir/tests/test_cb_cbor_simple.c.o
[  7%] Building C object CMakeFiles/test_cb_cbor_simple.dir/src/cb_cbor_simple.c.o
[ 11%] Linking C executable test_cb_cbor_simple
[ 11%] Built target test_cb_cbor_simple
Scanning dependencies of target test_fs
[ 14%] Building C object CMakeFiles/test_fs.dir/tests/test_fs.c.o
[ 18%] Building C object CMakeFiles/test_fs.dir/src/cb_fs.c.o
[ 22%] Linking C executable test_fs
[ 22%] Built target test_fs
Scanning dependencies of target test_cb_ops
[ 25%] Building C object CMakeFiles/test_cb_ops.dir/tests/test_cb_ops.c.o
[ 29%] Building C object CMakeFiles/test_cb_ops.dir/src/cb_ops.c.o
/home/abenhlal/cborg/src/cb_ops.c: In function ‘cb_ops_find_one’:
/home/abenhlal/cborg/src/cb_ops.c:32:50: warning: unused parameter ‘item_size’ [-Wunused-parameter]
   32 | off_t cb_ops_find_one(int fd, void *item, size_t item_size, off_t start_pos) {
      |                                           ~~~~~~~^~~~~~~~~
[ 33%] Building C object CMakeFiles/test_cb_ops.dir/src/cb_endianness.c.o
[ 37%] Building C object CMakeFiles/test_cb_ops.dir/src/cb_fs.c.o
[ 40%] Building C object CMakeFiles/test_cb_ops.dir/src/cb_cbor_int.c.o
[ 44%] Building C object CMakeFiles/test_cb_ops.dir/src/cb_cbor_simple.c.o
[ 48%] Linking C executable test_cb_ops
[ 48%] Built target test_cb_ops
Scanning dependencies of target cborg
[ 51%] Building C object CMakeFiles/cborg.dir/src/cb_cbor_int.c.o
[ 55%] Building C object CMakeFiles/cborg.dir/src/cb_cbor_simple.c.o
[ 59%] Building C object CMakeFiles/cborg.dir/src/cb_endianness.c.o
[ 62%] Building C object CMakeFiles/cborg.dir/src/cb_fs.c.o
[ 66%] Building C object CMakeFiles/cborg.dir/src/cb_ops.c.o
/home/abenhlal/cborg/src/cb_ops.c: In function ‘cb_ops_find_one’:
/home/abenhlal/cborg/src/cb_ops.c:32:50: warning: unused parameter ‘item_size’ [-Wunused-parameter]
   32 | off_t cb_ops_find_one(int fd, void *item, size_t item_size, off_t start_pos) {
      |                                           ~~~~~~~^~~~~~~~~
[ 70%] Building C object CMakeFiles/cborg.dir/src/cborg.c.o
/home/abenhlal/cborg/src/cborg.c: In function ‘main’:
/home/abenhlal/cborg/src/cborg.c:14:14: warning: unused parameter ‘argc’ [-Wunused-parameter]
   14 | int main(int argc, char const *argv[]) {
      |          ~~~~^~~~
/home/abenhlal/cborg/src/cborg.c:14:32: warning: unused parameter ‘argv’ [-Wunused-parameter]
   14 | int main(int argc, char const *argv[]) {
      |                    ~~~~~~~~~~~~^~~~~~
[ 74%] Linking C executable cborg
[ 74%] Built target cborg
Scanning dependencies of target test_cb_cbor_int
[ 77%] Building C object CMakeFiles/test_cb_cbor_int.dir/tests/test_cb_cbor_int.c.o
[ 81%] Building C object CMakeFiles/test_cb_cbor_int.dir/src/cb_cbor_int.c.o
[ 85%] Building C object CMakeFiles/test_cb_cbor_int.dir/src/cb_endianness.c.o
[ 88%] Linking C executable test_cb_cbor_int
[ 88%] Built target test_cb_cbor_int
Scanning dependencies of target test_endianness
[ 92%] Building C object CMakeFiles/test_endianness.dir/tests/test_endianness.c.o
[ 96%] Building C object CMakeFiles/test_endianness.dir/src/cb_endianness.c.o
[100%] Linking C executable test_endianness
[100%] Built target test_endianness
abenhlal@cborgdb-01:~/cborg/build$ make test
Running tests...
Test project /home/abenhlal/cborg/build
    Start 1: test_fs
1/5 Test #1: test_fs ..........................   Passed    0.00 sec
    Start 2: test_endianness
2/5 Test #2: test_endianness ..................   Passed    0.00 sec
    Start 3: test_cb_cbor_int
3/5 Test #3: test_cb_cbor_int .................   Passed    0.00 sec
    Start 4: test_cb_cbor_simple
4/5 Test #4: test_cb_cbor_simple ..............   Passed    0.00 sec
    Start 5: test_cb_ops
5/5 Test #5: test_cb_ops ......................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 5

Total Test time (real) =   0.01 sec
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
