### PR TITLE
fix(cbor): cbor_get_uint returned wrong value

### DIFF
--- a/src/cb_cbor.c
+++ b/src/cb_cbor.c
@@ -85,24 +85,24 @@ uint8_t cb_cbor_get_uint8(const uint8_t *item) {
 
 uint16_t cb_cbor_get_uint16(const uint8_t *item) {
 #ifdef IS_BIG_ENDIAN
-  return *(item+1);
+  return *((uint16_t*)(item+1));
 #else
-  return cb_bswap16(*(item+1));
+  return cb_bswap16(*((uint16_t*)(item+1)));
 #endif
 }
 
 uint32_t cb_cbor_get_uint32(const uint8_t *item) {
 #ifdef IS_BIG_ENDIAN
-  return *(item+1);
+  return *((uint32_t*)(item+1));
 #else
-  return cb_bswap32(*(item+1));
+  return cb_bswap32(*((uint32_t*)(item+1)));
 #endif
 }
 
 uint64_t cb_cbor_get_uint64(const uint8_t *item) {
 #ifdef IS_BIG_ENDIAN
-  return *(item+1);
+  return *((uint64_t*)(item+1));
 #else
-  return cb_bswap64(*(item+1));
+  return cb_bswap64(*((uint64_t*)(item+1)));
 #endif
 }


### PR DESCRIPTION
<!---
  Provide a general summary of your changes in the Title above 
  Examples:
    - "fix(cbor): ..."
-->

## Description
`cb_cbor_get_uint` functions returned wrong value for 16,32,64 bits

## Motivation and Context
 I need to get good value in cbor items 😉 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)