### PR TITLE
fix(fs): linux does not have d_namlen attribute in dirent struct

### DIFF
--- a/src/cb_fs.c
+++ b/src/cb_fs.c
@@ -62,14 +62,14 @@ int cb_fs_ls_dir(const char *dir_path, char *list, size_t list_size) {
     if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
       continue;
     if (entry->d_type == DT_DIR) {
-      if(written + entry->d_namlen + 1 <= list_size){
+      if(written + strlen(entry->d_name) + 1 <= list_size){
         if(written > 0)
           list[written] = '\n';
-        memcpy(list + written,entry->d_name, entry->d_namlen);
-        list[written + entry->d_namlen] = '\0';
-        written += entry->d_namlen + 1;
+        memcpy(list + written,entry->d_name, strlen(entry->d_name));
+        list[written + strlen(entry->d_name)] = '\0';
+        written += strlen(entry->d_name) + 1;
       } else {
-        return -1;
+        return -2;
       }
     }
   }
@@ -89,14 +89,14 @@ int cb_fs_ls_file(const char *dir_path, char *list, size_t list_size) {
 
   while ((entry = readdir(dirp)) != NULL) {
     if (entry->d_type == DT_REG) {
-      if(written + entry->d_namlen + 1 <= list_size){
+      if(written + strlen(entry->d_name) + 1 <= list_size){
         if(written > 0)
           list[written] = '\n';
-        memcpy(list + written,entry->d_name, entry->d_namlen);
-        list[written + entry->d_namlen] = '\0';
-        written += entry->d_namlen + 1;
+        memcpy(list + written,entry->d_name, strlen(entry->d_name));
+        list[written + strlen(entry->d_name)] = '\0';
+        written += strlen(entry->d_name) + 1;
       } else {
-        return -1;
+        return -2;
       }
     }
   }


### PR DESCRIPTION
<!---
  Provide a general summary of your changes in the Title above 
  Examples:
    - "fix(cbor): ..."
-->

## Description
Linux does not have d_namlen attribute in dirent struct

## Motivation and Context
replace by strlen()

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)