### PR TITLE
feat(ops): add create/drop/list db or collections

### DIFF
--- a/include/cb_ops.h
+++ b/include/cb_ops.h
@@ -9,6 +9,18 @@
 #include <unistd.h>
 #include <sys/types.h>
 
+int cb_ops_create_db(const char *db_name);
+
+int cb_ops_drop_db(const char *db_name);
+
+int cb_ops_list_dbs(char *list, size_t list_size);
+
+int cb_ops_create_collection(const char *db_name, const char *collection_name);
+
+int cb_ops_drop_collection(const char *db_name, const char *collection_name);
+
+int cb_ops_list_collections(const char *db_name, char *list, size_t list_size);
+
 ssize_t cb_ops_insert_one(int fd, const void *data, size_t data_size);
 
 off_t cb_ops_find_one(int fd, void *data, size_t data_size, off_t after_pos);


### PR DESCRIPTION
<!---
  Provide a general summary of your changes in the Title above 
  Examples:
    - "feat(bloom): ..."
    - "fix(cbor): ..."
-->

## Description
This PR add the following public functions:
```c
int cb_ops_create_db(const char *db_name);

int cb_ops_drop_db(const char *db_name);

int cb_ops_list_dbs(char *list, size_t list_size);

int cb_ops_create_collection(const char *db_name, const char *collection_name);

int cb_ops_drop_collection(const char *db_name, const char *collection_name);

int cb_ops_list_collections(const char *db_name, char *list, size_t list_size);
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need databases and collections before inserting items

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Each function is tested in the test_cb_ops.c file with <assert.h> library.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
