### PR TITLE
fix(cbor): change return type of cbor encoding functions

### DIFF
--- a/include/cb_cbor_simple.h
+++ b/include/cb_cbor_simple.h
@@ -13,6 +13,6 @@
 // ENCODING //
 //////////////
 
-ssize_t cb_cbor_encode_null(uint8_t *ev, ssize_t size);
+size_t cb_cbor_encode_null(uint8_t *ev, size_t size);
 
 #endif // _CB_CBOR_SIMPLE_H

--- a/include/cb_cbor_string.h
+++ b/include/cb_cbor_string.h
@@ -13,9 +13,9 @@
 // ENCODING //
 //////////////
 
-ssize_t cb_cbor_encode_string_start(uint64_t len, uint8_t *ev, ssize_t size);
+size_t cb_cbor_encode_string_start(uint64_t len, uint8_t *ev, size_t size);
 
-ssize_t cb_cbor_encode_string_definite(char *s, uint64_t s_len, uint8_t *ev, ssize_t ev_size);
+size_t cb_cbor_encode_string_definite(char *s, uint64_t s_len, uint8_t *ev, size_t ev_size);
 
 ///////////////
 // ACCESSORS //

--- a/src/cb_cbor_simple.c
+++ b/src/cb_cbor_simple.c
@@ -5,7 +5,7 @@
 
 #include "cb_cbor_simple.h"
 
-ssize_t cb_cbor_encode_null(uint8_t *ev, ssize_t size) {
+size_t cb_cbor_encode_null(uint8_t *ev, size_t size) {
   if (size >= 1) {
     *ev = 0xF6;
     return 1;

--- a/src/cb_cbor_string.c
+++ b/src/cb_cbor_string.c
@@ -14,13 +14,13 @@
 //////////////
 
 // STRING
-ssize_t cb_cbor_encode_string_start(uint64_t len, uint8_t *ev, ssize_t size) {
+size_t cb_cbor_encode_string_start(uint64_t len, uint8_t *ev, size_t size) {
   return _cb_cbor_encode_uint(len, ev, size, 0x60);
 }
 
-ssize_t cb_cbor_encode_string_definite(char *s, uint64_t s_len, uint8_t *ev, ssize_t ev_size) {
-  ssize_t written = cb_cbor_encode_string_start(s_len, ev, ev_size);
-  if(written  > 0 && ev_size >= written + (ssize_t)s_len) {
+size_t cb_cbor_encode_string_definite(char *s, uint64_t s_len, uint8_t *ev, size_t ev_size) {
+  size_t written = cb_cbor_encode_string_start(s_len, ev, ev_size);
+  if(written  > 0 && ev_size >= written + (size_t)s_len) {
     memcpy(ev + written, s, s_len);
     return written + s_len;
   }


### PR DESCRIPTION
## Description
cbor_encode functions does not return signed integer
