### PR TITLE
feat(server): allow multiple client on BSD systems using kqueue

### DIFF
--- a/include/common/net/server.h
+++ b/include/common/net/server.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2022-present Adil Benhlal <abenhlal@cborgdb.com>
+ * 
+ */
+
+#ifndef _CB_NET_SERVER_H
+#define _CB_NET_SERVER_H
+
+#include <netinet/in.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "common/net/socket.h"
+
+typedef struct server_t {
+  socket_t socket;
+  struct sockaddr_in address;
+} server_t;
+
+server_t *cb_net_server_new();
+
+void cb_net_server_delete(server_t *s);
+
+void cb_net_server_init(server_t *srv);
+
+void cb_net_server_destroy(server_t *srv);
+
+void cb_net_server_bind(server_t *srv, uint16_t port);
+
+void cb_net_server_listen(server_t *srv, uint64_t backlog);
+
+socket_t cb_net_server_accept(server_t *srv);
+
+#endif

--- a/include/common/net/socket.h
+++ b/include/common/net/socket.h
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2022-present Adil Benhlal <abenhlal@cborgdb.com>
+ * 
+ */
+
+#ifndef _CB_NET_SOCKET_H
+#define _CB_NET_SOCKET_H
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+
+typedef struct socket_t {
+  int fd;
+} socket_t;
+
+socket_t *cb_net_socket_new();
+
+void cb_net_socket_delete(socket_t *s);
+
+void cb_net_socket_init(socket_t *s);
+
+void cb_net_socket_destroy(socket_t *s);
+
+ssize_t cb_net_socket_read(socket_t *s, void *buf, size_t len);
+
+ssize_t cb_net_socket_write(socket_t *s, void *buf, size_t length);
+
+void cb_net_socket_connect(socket_t *s, const char *hostname, uint16_t port);
+
+#endif

--- a/src/common/net/server.c
+++ b/src/common/net/server.c
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2022-present Adil Benhlal <abenhlal@cborgdb.com>
+ * 
+ */
+
+#include "common/net/server.h"
+
+#include <netinet/in.h>
+#include <unistd.h>
+
+void cb_net_server_init(server_t *srv) {
+  cb_net_socket_init(&(srv->socket));
+  int opt = 1;
+  if (setsockopt(srv->socket.fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt))) {
+    perror("setsockopt");
+    exit(EXIT_FAILURE);
+  }
+}
+
+void cb_net_server_destroy(server_t *srv) {
+  cb_net_socket_destroy(&(srv->socket));
+}
+
+server_t *cb_net_server_new() {
+  server_t *srv = (server_t *)malloc(sizeof(server_t));
+  cb_net_server_init(srv);
+  return srv;
+}
+
+void cb_net_server_delete(server_t *srv) {
+  cb_net_server_destroy(srv);
+  free(srv);
+}
+
+void cb_net_server_bind(server_t *srv, uint16_t port) {
+  srv->address.sin_family = AF_INET;
+  srv->address.sin_addr.s_addr = INADDR_ANY;
+  srv->address.sin_port = htons(port);
+  if (bind(srv->socket.fd, (struct sockaddr *)&(srv->address),
+           sizeof(srv->address)) < 0) {
+    perror("bind failed");
+    exit(EXIT_FAILURE);
+  }
+}
+
+void cb_net_server_listen(server_t *srv, uint64_t backlog) {
+  if (listen(srv->socket.fd, (int)backlog) < 0) {
+    perror("listen");
+    exit(EXIT_FAILURE);
+  }
+}
+
+socket_t cb_net_server_accept(server_t *srv) {
+  int new_s;
+  socklen_t slen = sizeof(srv->address);
+  if ((new_s = accept(srv->socket.fd, (struct sockaddr *)&(srv->address),
+                      &slen)) < 0) {
+    perror("accept");
+    exit(EXIT_FAILURE);
+  }
+
+  socket_t s = {.fd = new_s};
+  return s;
+}

--- a/src/common/net/socket.c
+++ b/src/common/net/socket.c
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2022-present Adil Benhlal <abenhlal@cborgdb.com>
+ * 
+ */
+
+#include <errno.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <unistd.h>
+
+#include "common/net/socket.h"
+
+#define h_addr h_addr_list[0]
+
+void cb_net_socket_init(socket_t *s) {
+  if ((s->fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+    perror("socket failed");
+    exit(EXIT_FAILURE);
+  }
+}
+
+void cb_net_socket_destroy(socket_t *s) { close(s->fd); }
+
+socket_t *cb_net_socket_new() {
+  socket_t *s = (socket_t *)malloc(sizeof(socket_t));
+  cb_net_socket_init(s);
+  return s;
+}
+
+void cb_net_socket_delete(socket_t *s) {
+  cb_net_socket_destroy(s);
+  free(s);
+}
+
+ssize_t cb_net_socket_read(socket_t *s, void *buf, size_t nbyte) {
+  return read(s->fd, buf, nbyte);
+}
+
+ssize_t cb_net_socket_write(socket_t *s, void *buf, size_t nbyte) {
+  return write(s->fd, buf, nbyte);
+}
+
+void cb_net_socket_connect(socket_t *s, const char *hostname, uint16_t port) {
+  struct hostent *hostinfo = NULL;
+  struct sockaddr_in sin = {0};
+
+  hostinfo = gethostbyname(hostname);
+  if (hostinfo == NULL) {
+    fprintf(stderr, "Unknown host %s.\n", hostname);
+    exit(EXIT_FAILURE);
+  }
+  sin.sin_addr = *(struct in_addr *)hostinfo->h_addr;
+  sin.sin_port = htons(port);
+  sin.sin_family = AF_INET;
+
+  if (connect(s->fd, (struct sockaddr *)&sin, sizeof(struct sockaddr)) == -1) {
+    perror("connect()");
+    exit(errno);
+  }
+}


### PR DESCRIPTION
<!---
  Provide a general summary of your changes in the Title above 
  Examples:
    - "feat(bloom): ..."
    - "fix(cbor): ..."
-->

## Description
<!--- Describe your changes in detail -->
Enable multiple client on BSD systems with kqueue

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is my first code with kqueue 😉 
I want to offer the possibility to several clients to be able to be connected at the same time to CborgDB on BSD systems because I am developing on macOS but an another pull request will come for Linux with Epoll.
